### PR TITLE
[codex] Release 0.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Audit production dependencies
+        run: npm run security:audit
+
       - name: Check formatting
         run: npm run format:check
 

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ GitHub release bodies are generated from the matching versioned section in `RELE
 
 ## Recent release notes
 
-### 0.1.7
+### 0.2.0
 
-- Restore reader status bar hiding on Android and add a native reader chrome toggle.
-- Reapply Android reader immersive mode on resume and window focus so the gesture bar stays hidden more reliably.
-- Add a small extra bottom EPUB padding to clear the gesture navigation area.
-- Fix versioned release notes.
+- Keep Kavita auth keys out of cover and download URLs by using authenticated headers for those requests.
+- Disable Android app-data backup and narrow the Android FileProvider path used by the app.
+- Show a persistent warning when a saved Kavita server uses plain HTTP.
+- Add diagnostic redaction helpers and tests for common secret fields and auth query parameters.
 
 ## Screenshots
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,6 @@
 
 ## Unreleased
 
-- Release 0.2.0
 ## 0.2.0
 
 - Keep Kavita auth keys out of cover and download URLs by using authenticated headers for those requests.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,16 +2,22 @@
 
 ## Unreleased
 
+- Release 0.2.0
+## 0.2.0
+
+- Keep Kavita auth keys out of cover and download URLs by using authenticated headers for those requests.
+- Disable Android app-data backup and narrow the Android FileProvider path used by the app.
+- Show a persistent warning when a saved Kavita server uses plain HTTP.
+- Add diagnostic redaction helpers and tests for common secret fields and auth query parameters.
+- Add production dependency audit to pull-request CI.
 - Restore cross-device reading from Kavita's precise EPUB XPath instead of its coarse page ratio.
 - Convert Kavita EPUB paths into canonical CFIs so first-open restores land on the saved semantic location.
-
 - Improve progress sync across edge cases
 - Restore Kavita reading positions without immediately writing transient page-one locations back to the server.
 - Restore from Kavita's global book progress first, with its EPUB XPath as a fallback.
 - Calculate Kavita progress from the EPUB spine and page instead of EPUB.js's chapter-local percentage.
 - Prevent ordinary reader navigation and manual sync from accidentally marking books as completed.
 - Retry a failed Kavita progress read once and fall back to cached library progress instead of page one.
-
 - fix: restore kavita epub locations
 - Restore Kavita EPUB locations through namespaced XHTML and fall back to server page progress when an exact locator cannot be resolved.
 - fix: handle fresh install startup and kavita resume

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,9 +1,11 @@
 # Security
 
-- Auth keys never enter localStorage, SQLite, diagnostics, or logs.
+- Native auth keys never enter localStorage, SQLite, diagnostics, or logs.
 - Native credentials use `@aparajita/capacitor-secure-storage`: Android AES-GCM with a Keystore key and iOS Keychain without iCloud synchronization.
-- API keys use the `x-api-key` header except Kavita's cover route, which requires its documented query parameter. Covers are fetched once with native bridge logging disabled and cached privately.
+- API keys use the `x-api-key` header and are not placed in Kavita cover or download URLs.
 - EPUBs and SQLite live in app-private storage.
+- Android backup and device-transfer extraction are disabled for app data so downloaded books, cached covers, and local reading state are not copied into Android cloud backup.
+- The Android `FileProvider` is not exported and is limited to a private cache subdirectory.
 - The application CSP disallows inline scripts, objects, forms, and arbitrary script origins.
 - EPUB rendition iframes omit `allow-scripts`; content hooks remove scripts, nested frames, objects, embeds, and forms and block external link activation.
 - `allow-same-origin` is required for semantic range/CFI access. With scripts disabled, book content cannot execute code through that origin.
@@ -12,5 +14,11 @@
 - Diagnostics must redact `x-api-key`, authorization values, auth query parameters, and secure-storage contents.
 
 HTTP Kavita servers are supported only after a visible warning. Android and iOS transport policy must allow HTTP globally at the native layer, so the UI gate is a product control rather than a cryptographic boundary. HTTPS is the secure configuration.
+
+Browser preview stores its development-only auth key and local database in localStorage. Use the native Android or iOS app for secure credential storage.
+
+Use a dedicated non-administrator Kavita user for Turnleaf. Grant that user access only to the book libraries needed on the device, then create the auth key from that account. A Kavita auth key lets third-party apps act as that Kavita user, so an administrator key has administrator-level blast radius if it is stolen.
+
+Pull requests run formatting, linting, type checking, unit tests, production build, Android debug build, production dependency audit, dependency review, and CodeQL JavaScript/TypeScript analysis.
 
 EPUB.js's transitive `@xmldom/xmldom` dependency is overridden to patched release 0.9.10. Run `npm audit --omit=dev` for the current report.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:fullBackupContent="@xml/backup_rules"
         android:usesCleartextTraffic="true"
         android:networkSecurityConfig="@xml/network_security_config"
         android:icon="@mipmap/ic_launcher"

--- a/android/app/src/main/res/xml/backup_rules.xml
+++ b/android/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <exclude domain="root" path="." />
+</full-backup-content>

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="root" path="." />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="root" path="." />
+    </device-transfer>
+</data-extraction-rules>

--- a/android/app/src/main/res/xml/file_paths.xml
+++ b/android/app/src/main/res/xml/file_paths.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
-    <external-path name="my_images" path="." />
-    <cache-path name="my_cache_images" path="." />
+    <cache-path name="shared_cache" path="shared/" />
 </paths>

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "turnleaf",
   "private": true,
-  "version": "0.1.7",
+  "version": "0.2.0",
   "license": "MIT",
   "type": "module",
   "scripts": {
     "dev": "vite",
     "check": "svelte-check --tsconfig ./tsconfig.app.json",
     "lint": "eslint .",
+    "security:audit": "npm audit --omit=dev",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",

--- a/src/lib/components/Library.svelte
+++ b/src/lib/components/Library.svelte
@@ -258,6 +258,10 @@
     return book.pages ? Math.min(100, (book.pagesRead / book.pages) * 100) : 0;
   }
 
+  function insecureServer(): boolean {
+    return server.baseUrl.toLowerCase().startsWith('http://');
+  }
+
   onMount(async () => {
     const savedTheme = await getPreference('uiTheme');
     const savedMode = await getPreference('uiMode');
@@ -266,6 +270,7 @@
     pendingMode = savedMode === 'light' ? 'light' : mode;
     pendingAutoSync = savedAutoSync === null ? true : savedAutoSync === 'true';
     books = await getBooks(server.id);
+    void loadCovers(books);
     loading = false;
     offline = !(await Network.getStatus()).connected;
     if (!offline) await refresh();
@@ -301,7 +306,9 @@
 
   onDestroy(() => {
     if (syncTimer !== null) window.clearTimeout(syncTimer);
-    Object.values(covers).forEach(URL.revokeObjectURL);
+    Object.values(covers)
+      .filter((cover) => cover.startsWith('blob:'))
+      .forEach(URL.revokeObjectURL);
     cleanups.forEach((remove) => void remove());
   });
 
@@ -334,13 +341,15 @@
   }
 
   async function loadCovers(items: BookRecord[]): Promise<void> {
-    if (!nativePlatform) return;
     for (const book of items) {
       if (covers[book.seriesId]) continue;
       try {
+        const cover = nativePlatform
+          ? await cacheCover(client.coverUrl(book.seriesId), apiKey, book.seriesId)
+          : URL.createObjectURL(await client.getCover(book.seriesId));
         covers = {
           ...covers,
-          [book.seriesId]: await cacheCover(client.coverUrl(book.seriesId), apiKey, book.seriesId),
+          [book.seriesId]: cover,
         };
       } catch {
         /* Metadata remains useful without decorative covers. */
@@ -677,13 +686,20 @@
         onclick={() => void open(continueBook!)}
         transition:fade
       >
-        <img
-          class="h-24 w-16 shrink-0 rounded-lg object-cover shadow-md sm:h-28 sm:w-20"
-          src={covers[continueBook.seriesId] ?? client.coverUrl(continueBook.seriesId)}
-          loading="lazy"
-          decoding="async"
-          alt=""
-        />
+        {#if covers[continueBook.seriesId]}
+          <img
+            class="h-24 w-16 shrink-0 rounded-lg object-cover shadow-md sm:h-28 sm:w-20"
+            src={covers[continueBook.seriesId]}
+            loading="lazy"
+            decoding="async"
+            alt=""
+          />
+        {:else}
+          <div
+            class="h-24 w-16 shrink-0 rounded-lg shadow-md preset-filled-surface-200-800 sm:h-28 sm:w-20"
+            aria-hidden="true"
+          ></div>
+        {/if}
         <div class="min-w-0 flex-1">
           <p class="text-xs uppercase tracking-wider text-surface-700-300">Continue reading</p>
           <h2 class="mt-0.5 truncate font-serif text-xl leading-tight text-surface-950-50">
@@ -846,13 +862,15 @@
               <div
                 class="preset-tonal-surface relative aspect-[2/3] overflow-hidden rounded-lg shadow-md transition-shadow duration-300 group-hover:shadow-xl"
               >
-                <img
-                  class="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.04]"
-                  src={covers[book.seriesId] ?? client.coverUrl(book.seriesId)}
-                  loading="lazy"
-                  decoding="async"
-                  alt=""
-                />
+                {#if covers[book.seriesId]}
+                  <img
+                    class="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.04]"
+                    src={covers[book.seriesId]}
+                    loading="lazy"
+                    decoding="async"
+                    alt=""
+                  />
+                {/if}
                 {#if downloadingBookId === book.id}
                   <span
                     class="badge-icon preset-filled-primary-600-400 absolute left-2 top-2 h-7 w-7 p-0 shadow-md"
@@ -1178,6 +1196,12 @@
             <dd class="truncate text-right">{server.baseUrl}</dd>
           </div>
         </dl>
+        {#if insecureServer()}
+          <div class="alert preset-tonal-warning mt-4" role="alert">
+            Plain HTTP is enabled. Anyone on this network may be able to observe your reading
+            traffic and Kavita auth key. HTTPS is strongly recommended.
+          </div>
+        {/if}
 
         <form class="mt-4 grid gap-3" onsubmit={updateApiKey}>
           <label class="label">

--- a/src/lib/components/Onboarding.svelte
+++ b/src/lib/components/Onboarding.svelte
@@ -109,7 +109,8 @@
         >
           <input class="checkbox mt-0.5" type="checkbox" bind:checked={allowHttp} />
           <span
-            >Allow plain HTTP. Anyone on this network may be able to observe your reading traffic.</span
+            >Allow plain HTTP. Anyone on this network may be able to observe your reading traffic
+            and auth key.</span
           >
         </label>
       {/if}
@@ -125,7 +126,8 @@
           required
         />
         <span class="label-text text-xs text-surface-800-200">
-          Create this in Kavita for a dedicated non-administrator account.
+          Create this in Kavita for a dedicated non-administrator account with access only to the
+          book libraries you want on this device.
         </span>
       </label>
 

--- a/src/lib/kavita/client.test.ts
+++ b/src/lib/kavita/client.test.ts
@@ -23,17 +23,30 @@ beforeEach(() => {
   vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
 });
 
-it('builds authenticated cover URLs with the api key query parameter', () => {
+it('builds cover URLs without putting the api key in the query string', () => {
   const client = new KavitaClient('https://books.example.com', 'abc123');
-  expect(client.coverUrl(4)).toBe(
-    'https://books.example.com/api/Image/series-cover?seriesId=4&apiKey=abc123',
+  expect(client.coverUrl(4)).toBe('https://books.example.com/api/Image/series-cover?seriesId=4');
+});
+
+it('builds download URLs without putting the api key in the query string', () => {
+  const client = new KavitaClient('https://books.example.com', 'key with spaces');
+  expect(client.downloadUrl(42)).toBe(
+    'https://books.example.com/api/Download/chapter?chapterId=42',
   );
 });
 
-it('builds authenticated download URLs with the api key query parameter', () => {
-  const client = new KavitaClient('https://books.example.com', 'key with spaces');
-  expect(client.downloadUrl(42)).toBe(
-    'https://books.example.com/api/Download/chapter?chapterId=42&apiKey=key%20with%20spaces',
+it('loads covers with the api key header', async () => {
+  const client = new KavitaClient('https://books.example.com', 'abc123');
+
+  await client.getCover(4);
+
+  expect(fetch).toHaveBeenCalledWith(
+    'https://books.example.com/api/Image/series-cover?seriesId=4',
+    expect.objectContaining({
+      headers: expect.objectContaining({
+        'x-api-key': 'abc123',
+      }),
+    }),
   );
 });
 

--- a/src/lib/kavita/client.ts
+++ b/src/lib/kavita/client.ts
@@ -66,15 +66,11 @@ export class KavitaClient {
   }
 
   downloadUrl(chapterId: number): string {
-    return this.resolveUrl(
-      `/api/Download/chapter?chapterId=${chapterId}&apiKey=${encodeURIComponent(this.apiKey)}`,
-    );
+    return this.resolveUrl(`/api/Download/chapter?chapterId=${chapterId}`);
   }
 
   coverUrl(seriesId: number): string {
-    return this.resolveUrl(
-      `/api/Image/series-cover?seriesId=${seriesId}&apiKey=${encodeURIComponent(this.apiKey)}`,
-    );
+    return this.resolveUrl(`/api/Image/series-cover?seriesId=${seriesId}`);
   }
 
   async getCover(seriesId: number, signal?: AbortSignal): Promise<Blob> {
@@ -83,6 +79,7 @@ export class KavitaClient {
       if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
       const response = await CapacitorHttp.get({
         url,
+        headers: { 'x-api-key': this.apiKey },
         responseType: 'blob',
         connectTimeout: REQUEST_TIMEOUT_MS,
         readTimeout: REQUEST_TIMEOUT_MS,
@@ -97,7 +94,10 @@ export class KavitaClient {
     const timer = window.setTimeout(() => timeout.abort(), REQUEST_TIMEOUT_MS);
     try {
       const combined = signal ? AbortSignal.any([signal, timeout.signal]) : timeout.signal;
-      const response = await fetch(url, { signal: combined });
+      const response = await fetch(url, {
+        signal: combined,
+        headers: { 'x-api-key': this.apiKey },
+      });
       if (!response.ok) throw new KavitaError('The book cover could not be loaded.', 'server');
       return await response.blob();
     } finally {

--- a/src/lib/security/redaction.test.ts
+++ b/src/lib/security/redaction.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { redactDiagnosticText, redactDiagnosticValue } from './redaction';
+
+describe('diagnostic redaction', () => {
+  it('redacts known secret fields from structured diagnostics', () => {
+    expect(
+      redactDiagnosticValue({
+        server: 'https://read.example.com',
+        apiKey: 'secret-key',
+        headers: {
+          'x-api-key': 'header-secret',
+          Authorization: 'Bearer token-secret',
+        },
+        nested: [{ token: 'nested-token' }],
+      }),
+    ).toEqual({
+      server: 'https://read.example.com',
+      apiKey: '[redacted]',
+      headers: {
+        'x-api-key': '[redacted]',
+        Authorization: '[redacted]',
+      },
+      nested: [{ token: '[redacted]' }],
+    });
+  });
+
+  it('redacts auth query parameters from diagnostic strings', () => {
+    expect(
+      redactDiagnosticValue(
+        'https://read.example.com/api/Download/chapter?chapterId=7&apiKey=secret-key',
+      ),
+    ).toBe('https://read.example.com/api/Download/chapter?chapterId=7&apiKey=%5Bredacted%5D');
+  });
+
+  it('redacts common secret patterns from diagnostic text', () => {
+    expect(
+      redactDiagnosticText(
+        'x-api-key: secret Authorization=BearerToken https://x.test/path?token=abc123',
+      ),
+    ).toBe('x-api-key: [redacted] Authorization: [redacted] https://x.test/path?token=[redacted]');
+  });
+});

--- a/src/lib/security/redaction.ts
+++ b/src/lib/security/redaction.ts
@@ -1,0 +1,41 @@
+const SECRET_VALUE = '[redacted]';
+
+const SECRET_FIELDS = /\b(apiKey|api_key|x-api-key|authorization|auth|token|password)\b/i;
+
+function redactUrl(value: string): string {
+  try {
+    const url = new URL(value);
+    let changed = false;
+    for (const key of [...url.searchParams.keys()]) {
+      if (SECRET_FIELDS.test(key)) {
+        url.searchParams.set(key, SECRET_VALUE);
+        changed = true;
+      }
+    }
+    return changed ? url.toString() : value;
+  } catch {
+    return value;
+  }
+}
+
+export function redactDiagnosticValue(value: unknown): unknown {
+  if (typeof value === 'string') return redactUrl(value);
+  if (!value || typeof value !== 'object') return value;
+  if (Array.isArray(value)) return value.map(redactDiagnosticValue);
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => [
+      key,
+      SECRET_FIELDS.test(key) ? SECRET_VALUE : redactDiagnosticValue(entry),
+    ]),
+  );
+}
+
+export function redactDiagnosticText(value: string): string {
+  return value
+    .replace(/([?&](?:apiKey|api_key|auth|token|password)=)[^&#\s]+/gi, `$1${SECRET_VALUE}`)
+    .replace(
+      /(?<![?&])\b(apiKey|api_key|x-api-key|authorization|auth|token|password)\b\s*[:=]\s*["']?[^"',\s}]+/gi,
+      (_match, key: string) => `${key}: ${SECRET_VALUE}`,
+    );
+}


### PR DESCRIPTION
## Summary

- Bump Turnleaf to `0.2.0`.
- Promote the current unreleased notes into the new versioned release section.
- Update the README release snippet to match the new release.
- Keep the recent security hardening in the same release bundle.

## Validation

- `npm run format:check`
- `npm run check`
- `npm run lint`
- `npm test`
- `npm run security:audit`
- `npm run build`
- `npm run android:debug`
