### PR TITLE
Add a setting to keep the screen awake while reading

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix reader chrome, volume-button paging, and keep-awake not working on Android by registering their native plugins with the Capacitor bridge
 - Add a setting to keep the screen awake while reading
 
 ## 0.2.0

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add a setting to keep the screen awake while reading
+
 ## 0.2.0
 
 - Keep Kavita auth keys out of cover and download URLs by using authenticated headers for those requests.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Prevent reader native controls from being re-enabled after the reader is closed during startup.
 - Fix reader chrome, volume-button paging, and keep-awake not working on Android by registering their native plugins with the Capacitor bridge
 - Add a setting to keep the screen awake while reading
 

--- a/android/app/src/main/java/app/turnleaf/reader/KeepAwakePlugin.java
+++ b/android/app/src/main/java/app/turnleaf/reader/KeepAwakePlugin.java
@@ -1,0 +1,30 @@
+package app.turnleaf.reader;
+
+import android.app.Activity;
+import android.view.WindowManager;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+
+@CapacitorPlugin(name = "KeepAwake")
+public class KeepAwakePlugin extends Plugin {
+    @PluginMethod
+    public void setEnabled(PluginCall call) {
+        Boolean value = call.getBoolean("enabled", false);
+        boolean enabled = value != null && value;
+        Activity activity = getActivity();
+        if (activity != null) {
+            activity.runOnUiThread(
+                () -> {
+                    if (enabled) {
+                        activity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+                    } else {
+                        activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+                    }
+                }
+            );
+        }
+        call.resolve();
+    }
+}

--- a/android/app/src/main/java/app/turnleaf/reader/MainActivity.java
+++ b/android/app/src/main/java/app/turnleaf/reader/MainActivity.java
@@ -1,6 +1,7 @@
 package app.turnleaf.reader;
 
 import com.getcapacitor.BridgeActivity;
+import android.os.Bundle;
 import android.view.KeyEvent;
 import android.view.Window;
 import androidx.core.view.WindowCompat;
@@ -8,6 +9,14 @@ import androidx.core.view.WindowInsetsCompat;
 import androidx.core.view.WindowInsetsControllerCompat;
 
 public class MainActivity extends BridgeActivity {
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        registerPlugin(ReaderChromePlugin.class);
+        registerPlugin(VolumeButtonsPlugin.class);
+        registerPlugin(KeepAwakePlugin.class);
+        super.onCreate(savedInstanceState);
+    }
+
     @Override
     public void onResume() {
         super.onResume();

--- a/ios/App/App/TurnleafBridgeViewController.swift
+++ b/ios/App/App/TurnleafBridgeViewController.swift
@@ -13,6 +13,9 @@ final class TurnleafBridgeViewController: CAPBridgeViewController {
         if bridge?.plugin(withName: "ReaderChrome") == nil {
             bridge?.registerPluginInstance(TurnleafReaderChromePlugin())
         }
+        if bridge?.plugin(withName: "KeepAwake") == nil {
+            bridge?.registerPluginInstance(TurnleafKeepAwakePlugin())
+        }
     }
 
     override var prefersStatusBarHidden: Bool {
@@ -171,6 +174,23 @@ final class TurnleafVolumeButtonsController {
 
     private var volumeSlider: UISlider? {
         volumeView?.subviews.compactMap { $0 as? UISlider }.first
+    }
+}
+
+@objc(TurnleafKeepAwakePlugin)
+public final class TurnleafKeepAwakePlugin: CAPPlugin, CAPBridgedPlugin {
+    public let identifier = "TurnleafKeepAwakePlugin"
+    public let jsName = "KeepAwake"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "setEnabled", returnType: CAPPluginReturnPromise),
+    ]
+
+    @objc func setEnabled(_ call: CAPPluginCall) {
+        let enabled = call.getBool("enabled", false)
+        DispatchQueue.main.async {
+            UIApplication.shared.isIdleTimerDisabled = enabled
+        }
+        call.resolve()
     }
 }
 

--- a/src/lib/components/Reader.svelte
+++ b/src/lib/components/Reader.svelte
@@ -8,6 +8,7 @@
   import { KeepAwake } from '../native/keep-awake';
   import { ReaderChrome } from '../native/reader-chrome';
   import { VolumeButtons } from '../native/volume-buttons';
+  import { createReaderNativeFeatures } from '../native/reader-native-features';
   import {
     defaultAppearance,
     parseAppearance,
@@ -52,9 +53,20 @@
   let saveTimer: number | null = null;
   let resumeHandle: PluginListenerHandle | null = null;
   let syncingLatest = $state(false);
+  let destroyed = false;
+  const nativeFeatures = Capacitor.isNativePlatform()
+    ? createReaderNativeFeatures({
+        hideStatusBar: () => StatusBar.hide({ animation: Animation.None }),
+        showStatusBar: () => StatusBar.show({ animation: Animation.None }),
+        setReaderChrome: (enabled) => ReaderChrome.setEnabled({ enabled }),
+        setVolumeButtons: (enabled) => VolumeButtons.setEnabled({ enabled }),
+        setKeepAwake: (enabled) => KeepAwake.setEnabled({ enabled }),
+      })
+    : null;
 
   onMount(async () => {
     const saved = await getPreference('appearance');
+    if (destroyed) return;
     if (saved) appearance = parseAppearance(saved);
     session = new ReaderSession(bookUrl);
     try {
@@ -65,58 +77,54 @@
         initialPercentage,
         appearance,
         (next, origin) => {
+          if (destroyed) return;
           location = next;
           if (origin === 'navigation') onRelocated(next);
         },
         (zone) => {
+          if (destroyed) return;
           if (zone === 'center') {
             if (controlsVisible) controlsVisible = false;
             else showControls();
           } else void turn(zone);
         },
       );
+      if (destroyed) return;
       toc = session.tableOfContents();
     } catch {
+      if (destroyed) return;
       error = 'This EPUB could not be opened. The download may be incomplete or corrupted.';
       return;
     }
 
-    if (Capacitor.isNativePlatform()) {
+    if (nativeFeatures) {
+      await nativeFeatures.enable(appearance.keepAwake);
+      if (destroyed) return;
+
       try {
-        await StatusBar.hide({ animation: Animation.None });
+        const handle = await App.addListener('appStateChange', ({ isActive }) => {
+          if (!destroyed && isActive) void syncLatestLocation(false);
+        });
+        if (destroyed) {
+          await handle.remove();
+          return;
+        }
+        resumeHandle = handle;
       } catch {
-        // The reader still works if the platform refuses to hide the bar.
+        // Resume syncing is optional; the reader itself should keep working.
       }
-      try {
-        await ReaderChrome.setEnabled({ enabled: true });
-      } catch {
-        // The reader still works if the platform cannot hide system bars.
-      }
-      try {
-        await VolumeButtons.setEnabled({ enabled: true });
-      } catch {
-        // Volume-button paging is optional; the reader itself should keep working.
-      }
-      try {
-        await KeepAwake.setEnabled({ enabled: appearance.keepAwake });
-      } catch {
-        // Keeping the screen awake is optional; the reader itself should keep working.
-      }
-      resumeHandle = await App.addListener('appStateChange', ({ isActive }) => {
-        if (isActive) void syncLatestLocation(false);
-      });
     }
   });
 
   onDestroy(() => {
+    destroyed = true;
     if (hideTimer !== null) window.clearTimeout(hideTimer);
     if (saveTimer !== null) window.clearTimeout(saveTimer);
-    void resumeHandle?.remove();
+    const handle = resumeHandle;
+    resumeHandle = null;
+    void handle?.remove();
     void setPreference('appearance', serializeAppearance(appearance));
-    if (Capacitor.isNativePlatform()) void StatusBar.show({ animation: Animation.None });
-    if (Capacitor.isNativePlatform()) void ReaderChrome.setEnabled({ enabled: false });
-    if (Capacitor.isNativePlatform()) void VolumeButtons.setEnabled({ enabled: false });
-    if (Capacitor.isNativePlatform()) void KeepAwake.setEnabled({ enabled: false });
+    void nativeFeatures?.disable();
     session?.destroy();
   });
 
@@ -143,10 +151,8 @@
   function updateAppearance(patch: Partial<Appearance>): void {
     appearance = { ...appearance, ...patch };
     session?.applyAppearance(appearance);
-    if (patch.keepAwake !== undefined && Capacitor.isNativePlatform()) {
-      void KeepAwake.setEnabled({ enabled: patch.keepAwake }).catch(() => {
-        // Keeping the screen awake is optional; the reader itself should keep working.
-      });
+    if (patch.keepAwake !== undefined) {
+      void nativeFeatures?.setKeepAwake(patch.keepAwake);
     }
     if (saveTimer !== null) window.clearTimeout(saveTimer);
     saveTimer = window.setTimeout(

--- a/src/lib/components/Reader.svelte
+++ b/src/lib/components/Reader.svelte
@@ -54,6 +54,7 @@
   let resumeHandle: PluginListenerHandle | null = null;
   let syncingLatest = $state(false);
   let destroyed = false;
+  let appearanceLoaded = false;
   const nativeFeatures = Capacitor.isNativePlatform()
     ? createReaderNativeFeatures({
         hideStatusBar: () => StatusBar.hide({ animation: Animation.None }),
@@ -68,6 +69,7 @@
     const saved = await getPreference('appearance');
     if (destroyed) return;
     if (saved) appearance = parseAppearance(saved);
+    appearanceLoaded = true;
     session = new ReaderSession(bookUrl);
     try {
       await session.open(
@@ -123,7 +125,7 @@
     const handle = resumeHandle;
     resumeHandle = null;
     void handle?.remove();
-    void setPreference('appearance', serializeAppearance(appearance));
+    if (appearanceLoaded) void setPreference('appearance', serializeAppearance(appearance));
     void nativeFeatures?.disable();
     session?.destroy();
   });

--- a/src/lib/components/Reader.svelte
+++ b/src/lib/components/Reader.svelte
@@ -5,6 +5,7 @@
   import { fade, fly } from 'svelte/transition';
   import { Animation, StatusBar } from '@capacitor/status-bar';
   import { getPreference, setPreference } from '../database/database';
+  import { KeepAwake } from '../native/keep-awake';
   import { ReaderChrome } from '../native/reader-chrome';
   import { VolumeButtons } from '../native/volume-buttons';
   import {
@@ -96,6 +97,11 @@
       } catch {
         // Volume-button paging is optional; the reader itself should keep working.
       }
+      try {
+        await KeepAwake.setEnabled({ enabled: appearance.keepAwake });
+      } catch {
+        // Keeping the screen awake is optional; the reader itself should keep working.
+      }
       resumeHandle = await App.addListener('appStateChange', ({ isActive }) => {
         if (isActive) void syncLatestLocation(false);
       });
@@ -110,6 +116,7 @@
     if (Capacitor.isNativePlatform()) void StatusBar.show({ animation: Animation.None });
     if (Capacitor.isNativePlatform()) void ReaderChrome.setEnabled({ enabled: false });
     if (Capacitor.isNativePlatform()) void VolumeButtons.setEnabled({ enabled: false });
+    if (Capacitor.isNativePlatform()) void KeepAwake.setEnabled({ enabled: false });
     session?.destroy();
   });
 
@@ -136,6 +143,11 @@
   function updateAppearance(patch: Partial<Appearance>): void {
     appearance = { ...appearance, ...patch };
     session?.applyAppearance(appearance);
+    if (patch.keepAwake !== undefined && Capacitor.isNativePlatform()) {
+      void KeepAwake.setEnabled({ enabled: patch.keepAwake }).catch(() => {
+        // Keeping the screen awake is optional; the reader itself should keep working.
+      });
+    }
     if (saveTimer !== null) window.clearTimeout(saveTimer);
     saveTimer = window.setTimeout(
       () => void setPreference('appearance', serializeAppearance(appearance)),
@@ -445,6 +457,15 @@
               onchange={(event) => updateAppearance({ progressBar: event.currentTarget.checked })}
             />
             Progress bar
+          </label>
+          <label class="mt-4 flex min-h-12 items-center gap-3">
+            <input
+              class="checkbox"
+              type="checkbox"
+              checked={appearance.keepAwake}
+              onchange={(event) => updateAppearance({ keepAwake: event.currentTarget.checked })}
+            />
+            Keep screen on while reading
           </label>
         </section>
       {/if}

--- a/src/lib/native/keep-awake.ts
+++ b/src/lib/native/keep-awake.ts
@@ -1,0 +1,7 @@
+import { registerPlugin } from '@capacitor/core';
+
+export interface KeepAwakePlugin {
+  setEnabled(options: { enabled: boolean }): Promise<void>;
+}
+
+export const KeepAwake = registerPlugin<KeepAwakePlugin>('KeepAwake');

--- a/src/lib/native/reader-native-features.test.ts
+++ b/src/lib/native/reader-native-features.test.ts
@@ -16,6 +16,37 @@ function actions(overrides: Partial<ReaderNativeFeatureActions> = {}): ReaderNat
 }
 
 describe('reader native features', () => {
+  it('finishes an old reader teardown before enabling a newly opened reader', async () => {
+    let releaseOldRequest!: () => void;
+    const calls: string[] = [];
+    const oldReader = createReaderNativeFeatures(
+      actions({
+        setKeepAwake: async (enabled) => {
+          calls.push(`old:${enabled}`);
+          if (enabled) {
+            await new Promise<void>((resolve) => (releaseOldRequest = resolve));
+          }
+        },
+      }),
+    );
+    const newReader = createReaderNativeFeatures(
+      actions({
+        setKeepAwake: async (enabled) => {
+          calls.push(`new:${enabled}`);
+        },
+      }),
+    );
+    const oldSetup = oldReader.enable(true);
+    await vi.waitFor(() => expect(calls).toEqual(['old:true']));
+    const oldTeardown = oldReader.disable();
+    const newSetup = newReader.enable(true);
+    releaseOldRequest();
+    await Promise.all([oldSetup, oldTeardown, newSetup]);
+
+    expect(calls).toEqual(['old:true', 'old:false', 'new:true']);
+    await newReader.disable();
+  });
+
   it('queues teardown after an in-flight enable and skips stale setup', async () => {
     let releaseHide!: () => void;
     const hideStatusBar = vi.fn(

--- a/src/lib/native/reader-native-features.test.ts
+++ b/src/lib/native/reader-native-features.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createReaderNativeFeatures,
+  type ReaderNativeFeatureActions,
+} from './reader-native-features';
+
+function actions(overrides: Partial<ReaderNativeFeatureActions> = {}): ReaderNativeFeatureActions {
+  return {
+    hideStatusBar: vi.fn(async () => undefined),
+    showStatusBar: vi.fn(async () => undefined),
+    setReaderChrome: vi.fn(async () => undefined),
+    setVolumeButtons: vi.fn(async () => undefined),
+    setKeepAwake: vi.fn(async () => undefined),
+    ...overrides,
+  };
+}
+
+describe('reader native features', () => {
+  it('queues teardown after an in-flight enable and skips stale setup', async () => {
+    let releaseHide!: () => void;
+    const hideStatusBar = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseHide = resolve;
+        }),
+    );
+    const nativeActions = actions({ hideStatusBar });
+    const features = createReaderNativeFeatures(nativeActions);
+
+    const enabling = features.enable(true);
+    await Promise.resolve();
+    const disabling = features.disable();
+    releaseHide();
+
+    await Promise.all([enabling, disabling]);
+
+    expect(nativeActions.hideStatusBar).toHaveBeenCalledOnce();
+    expect(nativeActions.showStatusBar).toHaveBeenCalledOnce();
+    expect(nativeActions.setReaderChrome).toHaveBeenCalledWith(false);
+    expect(nativeActions.setVolumeButtons).toHaveBeenCalledWith(false);
+    expect(nativeActions.setKeepAwake).toHaveBeenCalledWith(false);
+    expect(nativeActions.setReaderChrome).not.toHaveBeenCalledWith(true);
+    expect(nativeActions.setVolumeButtons).not.toHaveBeenCalledWith(true);
+    expect(nativeActions.setKeepAwake).not.toHaveBeenCalledWith(true);
+  });
+
+  it('ignores preference changes after teardown', async () => {
+    const nativeActions = actions();
+    const features = createReaderNativeFeatures(nativeActions);
+
+    await features.disable();
+    await features.setKeepAwake(true);
+
+    expect(nativeActions.setKeepAwake).toHaveBeenCalledWith(false);
+    expect(nativeActions.setKeepAwake).not.toHaveBeenCalledWith(true);
+  });
+
+  it('applies teardown after a pending keep-awake request resolves', async () => {
+    let releaseKeepAwake!: () => void;
+    const setKeepAwake = vi.fn((enabled: boolean) =>
+      enabled
+        ? new Promise<void>((resolve) => {
+            releaseKeepAwake = resolve;
+          })
+        : Promise.resolve(),
+    );
+    const nativeActions = actions({ setKeepAwake });
+    const features = createReaderNativeFeatures(nativeActions);
+
+    const enabling = features.enable(true);
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    expect(setKeepAwake).toHaveBeenCalledWith(true);
+
+    const disabling = features.disable();
+    releaseKeepAwake();
+    await Promise.all([enabling, disabling]);
+
+    expect(setKeepAwake.mock.calls.map(([enabled]) => enabled)).toEqual([true, false]);
+  });
+});

--- a/src/lib/native/reader-native-features.ts
+++ b/src/lib/native/reader-native-features.ts
@@ -12,12 +12,14 @@ export interface ReaderNativeFeatures {
   disable: () => Promise<void>;
 }
 
+// Native controls belong to the app window, so an old reader's teardown must
+// finish before a newly opened reader enables them.
+let queue = Promise.resolve();
+
 export function createReaderNativeFeatures(
   actions: ReaderNativeFeatureActions,
 ): ReaderNativeFeatures {
   let active = true;
-  let generation = 0;
-  let queue = Promise.resolve();
 
   function enqueue(operation: () => Promise<void>): Promise<void> {
     const next = queue.then(operation, operation);
@@ -34,24 +36,22 @@ export function createReaderNativeFeatures(
   }
 
   function enable(keepAwake: boolean): Promise<void> {
-    const requestedGeneration = generation;
     return enqueue(async () => {
-      if (!active || requestedGeneration !== generation) return;
+      if (!active) return;
 
       await attempt(actions.hideStatusBar);
-      if (!active || requestedGeneration !== generation) return;
+      if (!active) return;
       await attempt(() => actions.setReaderChrome(true));
-      if (!active || requestedGeneration !== generation) return;
+      if (!active) return;
       await attempt(() => actions.setVolumeButtons(true));
-      if (!active || requestedGeneration !== generation) return;
+      if (!active) return;
       await attempt(() => actions.setKeepAwake(keepAwake));
     });
   }
 
   function setKeepAwake(enabled: boolean): Promise<void> {
-    const requestedGeneration = generation;
     return enqueue(async () => {
-      if (!active || requestedGeneration !== generation) return;
+      if (!active) return;
       await attempt(() => actions.setKeepAwake(enabled));
     });
   }
@@ -59,7 +59,6 @@ export function createReaderNativeFeatures(
   function disable(): Promise<void> {
     if (!active) return queue;
     active = false;
-    generation += 1;
     return enqueue(async () => {
       await attempt(actions.showStatusBar);
       await attempt(() => actions.setReaderChrome(false));

--- a/src/lib/native/reader-native-features.ts
+++ b/src/lib/native/reader-native-features.ts
@@ -1,0 +1,72 @@
+export interface ReaderNativeFeatureActions {
+  hideStatusBar: () => Promise<void>;
+  showStatusBar: () => Promise<void>;
+  setReaderChrome: (enabled: boolean) => Promise<void>;
+  setVolumeButtons: (enabled: boolean) => Promise<void>;
+  setKeepAwake: (enabled: boolean) => Promise<void>;
+}
+
+export interface ReaderNativeFeatures {
+  enable: (keepAwake: boolean) => Promise<void>;
+  setKeepAwake: (enabled: boolean) => Promise<void>;
+  disable: () => Promise<void>;
+}
+
+export function createReaderNativeFeatures(
+  actions: ReaderNativeFeatureActions,
+): ReaderNativeFeatures {
+  let active = true;
+  let generation = 0;
+  let queue = Promise.resolve();
+
+  function enqueue(operation: () => Promise<void>): Promise<void> {
+    const next = queue.then(operation, operation);
+    queue = next.catch(() => undefined);
+    return next;
+  }
+
+  async function attempt(operation: () => Promise<void>): Promise<void> {
+    try {
+      await operation();
+    } catch {
+      // Native reader helpers are optional and must not prevent reading.
+    }
+  }
+
+  function enable(keepAwake: boolean): Promise<void> {
+    const requestedGeneration = generation;
+    return enqueue(async () => {
+      if (!active || requestedGeneration !== generation) return;
+
+      await attempt(actions.hideStatusBar);
+      if (!active || requestedGeneration !== generation) return;
+      await attempt(() => actions.setReaderChrome(true));
+      if (!active || requestedGeneration !== generation) return;
+      await attempt(() => actions.setVolumeButtons(true));
+      if (!active || requestedGeneration !== generation) return;
+      await attempt(() => actions.setKeepAwake(keepAwake));
+    });
+  }
+
+  function setKeepAwake(enabled: boolean): Promise<void> {
+    const requestedGeneration = generation;
+    return enqueue(async () => {
+      if (!active || requestedGeneration !== generation) return;
+      await attempt(() => actions.setKeepAwake(enabled));
+    });
+  }
+
+  function disable(): Promise<void> {
+    if (!active) return queue;
+    active = false;
+    generation += 1;
+    return enqueue(async () => {
+      await attempt(actions.showStatusBar);
+      await attempt(() => actions.setReaderChrome(false));
+      await attempt(() => actions.setVolumeButtons(false));
+      await attempt(() => actions.setKeepAwake(false));
+    });
+  }
+
+  return { enable, setKeepAwake, disable };
+}

--- a/src/lib/reader/appearance.test.ts
+++ b/src/lib/reader/appearance.test.ts
@@ -18,4 +18,9 @@ describe('appearance serialization', () => {
     expect(parseAppearance('{}').progressBar).toBe(true);
     expect(parseAppearance('{"progressBar":false}').progressBar).toBe(false);
   });
+
+  it('defaults keeping the screen awake off', () => {
+    expect(parseAppearance('{}').keepAwake).toBe(false);
+    expect(parseAppearance('{"keepAwake":true}').keepAwake).toBe(true);
+  });
 });

--- a/src/lib/reader/appearance.ts
+++ b/src/lib/reader/appearance.ts
@@ -11,6 +11,7 @@ export interface Appearance {
   publisherStyles: boolean;
   hyphenation: boolean;
   progressBar: boolean;
+  keepAwake: boolean;
 }
 
 export const defaultAppearance: Appearance = {
@@ -24,6 +25,7 @@ export const defaultAppearance: Appearance = {
   publisherStyles: true,
   hyphenation: false,
   progressBar: true,
+  keepAwake: false,
 };
 
 export function serializeAppearance(value: Appearance): string {


### PR DESCRIPTION
## Summary

Adds a setting to keep the screen awake while reading. Its toggle is in the reader options.
It also fixes the Android navigation buttons not disappearing on the reader.

Closes #49 and #45.

## Checks

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run check`
- [x] `npm test`
- [x] `npm run build`
- [x] `npm run android:debug`

## Security

- [x] No secrets or credentials were added
- [ ] Dependency changes are intentional
- [ ] Any user-facing HTML is sanitized
