### PR TITLE
Refresh library progress after reader navigation

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Refresh library progress from local storage after reader navigation, including when returning with Android Back or the reader Back button.
+
 ## 0.2.0
 
 - Keep Kavita auth keys out of cover and download URLs by using authenticated headers for those requests.

--- a/src/lib/components/Library.svelte
+++ b/src/lib/components/Library.svelte
@@ -483,6 +483,7 @@
       location.percentage,
       location.spineIndex,
     );
+    books = await getBooks(server.id);
     if (syncTimer !== null) window.clearTimeout(syncTimer);
     syncTimer = window.setTimeout(() => void flushProgress(client).catch(() => {}), 2_500);
   }


### PR DESCRIPTION
Page turns saved progress locally, but the library retained its old book records when the reader closed. Reload the local records after each successful progress save so both Back paths show current progress and Continue Reading order, including offline.

Closes #44.

Validation: type check, all 44 tests, lint, formatting, and production web build passed. Android device behavior was not tested locally.
