### PR TITLE
Keep reader text inside Android safe-area insets

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Size the reader viewport between its safe-area insets so Android navigation bars and the bottom margin do not cover book text.
+
 ## 0.2.0
 
 - Keep Kavita auth keys out of cover and download URLs by using authenticated headers for those requests.

--- a/src/lib/components/Reader.svelte
+++ b/src/lib/components/Reader.svelte
@@ -518,8 +518,12 @@
     --reader-overlay-top: color-mix(in oklab, var(--reader-text) 34%, transparent);
     --reader-overlay-bottom: color-mix(in oklab, var(--reader-text) 28%, transparent);
     --reader-bar-text: var(--color-surface-950);
-    --reader-safe-top: max(0.5rem, env(safe-area-inset-top));
-    --reader-safe-bottom: max(1rem, env(safe-area-inset-bottom));
+    --reader-safe-top: max(0.5rem, env(safe-area-inset-top, 0px), var(--safe-area-inset-top, 0px));
+    --reader-safe-bottom: max(
+      1rem,
+      env(safe-area-inset-bottom, 0px),
+      var(--safe-area-inset-bottom, 0px)
+    );
     --reader-progress-height: 0.25rem;
   }
 
@@ -528,7 +532,7 @@
     inset: var(--reader-safe-top) 0 var(--reader-safe-bottom) 0;
     overflow: hidden;
     width: 100%;
-    height: 100%;
+    height: auto;
     min-width: 0;
     max-width: 100%;
     contain: layout paint;


### PR DESCRIPTION
The reader viewport combined top/bottom positioning with `height: 100%`, causing CSS to ignore its bottom constraint. Let the viewport height follow its insets and include Capacitor's native safe-area CSS variables when calculating its top and bottom boundaries.

Closes #45.

Validation: Svelte type check and production build passed. Headless Chrome layout checks passed for bottom insets of 0, 24, 48, and 96 pixels; the viewport preserves the 16px minimum margin and clears larger insets. Physical Android navigation modes still need device verification.
