### PR TITLE
Restore production audit with patched DOMPurify and xmldom

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Update DOMPurify and the EPUB XML parser to patched releases so production dependency audits pass.
+
 ## 0.2.0
 
 - Keep Kavita auth keys out of cover and download URLs by using authenticated headers for those requests.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "turnleaf",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "turnleaf",
-      "version": "0.1.4",
+      "version": "0.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -18,7 +18,7 @@
         "@capacitor/filesystem": "^8.1.2",
         "@capacitor/network": "^8.0.1",
         "@capacitor/status-bar": "^8.0.2",
-        "dompurify": "^3.2.6",
+        "dompurify": "^3.4.15",
         "epubjs": "^0.3.93",
         "jeep-sqlite": "^2.8.0",
         "sql.js": "^1.14.1",
@@ -2238,9 +2238,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
-      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "version": "0.9.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.12.tgz",
+      "integrity": "sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==",
       "license": "MIT",
       "engines": {
         "node": ">=14.6"
@@ -3307,9 +3307,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.15.tgz",
+      "integrity": "sha512-EUBjM+B+lkDE41iE82DDSCfkoPGfXx8IxFxPMjNzm/Uk4xDet77rTN9wqlxlVg71kK7XGuUMv6wUxJUwwv+Xyw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@capacitor/filesystem": "^8.1.2",
     "@capacitor/network": "^8.0.1",
     "@capacitor/status-bar": "^8.0.2",
-    "dompurify": "^3.2.6",
+    "dompurify": "^3.4.15",
     "epubjs": "^0.3.93",
     "jeep-sqlite": "^2.8.0",
     "sql.js": "^1.14.1",
@@ -65,7 +65,7 @@
   },
   "overrides": {
     "epubjs": {
-      "@xmldom/xmldom": "0.9.10"
+      "@xmldom/xmldom": "0.9.12"
     }
   }
 }


### PR DESCRIPTION
Current pull-request CI stops at the production dependency audit because the lockfile contains vulnerable DOMPurify and xmldom releases. Update DOMPurify to 3.4.15 and the epubjs xmldom override to 0.9.12, retaining the existing audit gate.

This is a prerequisite for validating the recent PRs, including #38, #41, and #42. It also synchronizes the lockfile root version with package.json.

Validation: `npm audit --omit=dev` reports zero vulnerabilities; all 44 tests, type check, lint, formatting, and production build pass. A clean Android debug APK build also passed locally with Java 21 and the installed Android SDK.
