### PR TITLE
Show EPUBs nested in Kavita series volumes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Include EPUBs nested in Kavita series volumes while preserving existing local book records.
+
 ## 0.2.0
 
 - Keep Kavita auth keys out of cover and download URLs by using authenticated headers for those requests.

--- a/src/lib/components/Library.svelte
+++ b/src/lib/components/Library.svelte
@@ -27,7 +27,7 @@
     verifyDownloadedEpub,
   } from '../downloads/native-download';
   import { KavitaClient } from '../kavita/client';
-  import { mapSeriesToBook } from '../kavita/mapper';
+  import { mapSeriesToBooks } from '../kavita/mapper';
   import type { KavitaProgress } from '../kavita/types';
   import type { ReaderLocation } from '../reader/session';
   import { removeApiKey, saveApiKey } from '../native/credentials';
@@ -318,15 +318,14 @@
     message = '';
     try {
       const series = await client.getBookSeries();
-      const mapped = await Promise.all(
-        series.map(async (item) =>
-          mapSeriesToBook(server.id, item, await client.getSeriesDetail(item.id)),
-        ),
-      );
-      await replaceBooks(
-        server.id,
-        mapped.filter((item): item is BookRecord => item !== null),
-      );
+      const mapped = (
+        await Promise.all(
+          series.map(async (item) =>
+            mapSeriesToBooks(server.id, item, await client.getSeriesDetail(item.id)),
+          ),
+        )
+      ).flat();
+      await replaceBooks(server.id, mapped);
       books = await getBooks(server.id);
       void loadCovers(books);
       offline = false;

--- a/src/lib/kavita/mapper.test.ts
+++ b/src/lib/kavita/mapper.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from 'vitest';
-import { mapSeriesToBook } from './mapper';
+import { mapSeriesToBooks } from './mapper';
 import type { KavitaSeries, KavitaSeriesDetail } from './types';
 
 it('maps a Kavita standalone EPUB special into one local book', () => {
@@ -30,12 +30,94 @@ it('maps a Kavita standalone EPUB special into one local book', () => {
   const detail = {
     chapters: [],
     specials: [special],
+    volumes: [],
     storylineChapters: [],
   } satisfies KavitaSeriesDetail;
-  expect(mapSeriesToBook('primary', series, detail)).toMatchObject({
+  expect(mapSeriesToBooks('primary', series, detail)).toHaveLength(1);
+  expect(mapSeriesToBooks('primary', series, detail)[0]).toMatchObject({
     id: 'primary:7:7',
     author: 'Benjamin Wood',
     chapterId: 7,
     fileSize: 799783,
   });
+});
+
+it('maps every EPUB chapter nested in Kavita volumes', () => {
+  const series = {
+    id: 82,
+    name: 'The Seven Great Monarchies',
+    libraryId: 1,
+    format: 3,
+    pages: 25,
+    pagesRead: 0,
+    created: '2026-09-05',
+    latestReadDate: '0001-01-01T00:00:00',
+    coverImage: 'cover.png',
+  } satisfies KavitaSeries;
+  const chapter = (
+    id: number,
+    volumeId: number,
+    titleName: string,
+  ): KavitaSeriesDetail['chapters'][number] => ({
+    id,
+    title: `Book ${titleName}`,
+    titleName,
+    volumeId,
+    pages: 10,
+    pagesRead: 0,
+    summary: '',
+    format: 3,
+    files: [{ id, bytes: 1000 + id, extension: '.epub', format: 3 }],
+    writers: [{ name: 'George Rawlinson' }],
+    lastReadingProgressUtc: '0001-01-01T00:00:00',
+  });
+  const detail = {
+    chapters: [],
+    specials: [],
+    volumes: [
+      { id: 188, chapters: [chapter(1406, 188, 'Vol 3')] },
+      { id: 189, chapters: [chapter(1407, 189, 'Vol 5')] },
+    ],
+    storylineChapters: [],
+  } satisfies KavitaSeriesDetail;
+
+  expect(mapSeriesToBooks('primary', series, detail).map((book) => book.id)).toEqual([
+    'primary:82:1406',
+    'primary:82:1407',
+  ]);
+});
+
+it('deduplicates a chapter exposed both flat and inside its volume', () => {
+  const series = {
+    id: 9,
+    name: 'A Series',
+    libraryId: 1,
+    format: 3,
+    pages: 10,
+    pagesRead: 0,
+    created: '2026-09-05',
+    latestReadDate: '0001-01-01T00:00:00',
+    coverImage: 'cover.png',
+  } satisfies KavitaSeries;
+  const chapter = {
+    id: 90,
+    title: 'Book One',
+    titleName: 'Book One',
+    volumeId: 9,
+    pages: 10,
+    pagesRead: 0,
+    summary: '',
+    format: 3,
+    files: [{ id: 90, bytes: 900, extension: '.epub', format: 3 }],
+    writers: [],
+    lastReadingProgressUtc: '0001-01-01T00:00:00',
+  };
+  const detail = {
+    chapters: [chapter],
+    specials: [],
+    volumes: [{ id: 9, chapters: [chapter] }],
+    storylineChapters: [],
+  } satisfies KavitaSeriesDetail;
+
+  expect(mapSeriesToBooks('primary', series, detail)).toHaveLength(1);
 });

--- a/src/lib/kavita/mapper.test.ts
+++ b/src/lib/kavita/mapper.test.ts
@@ -121,3 +121,84 @@ it('deduplicates a chapter exposed both flat and inside its volume', () => {
 
   expect(mapSeriesToBooks('primary', series, detail)).toHaveLength(1);
 });
+
+it('keeps chapter progress and dates separate from series aggregates', () => {
+  const series = {
+    id: 12,
+    name: 'Mixed Progress',
+    libraryId: 1,
+    format: 3,
+    pages: 20,
+    pagesRead: 12,
+    created: '2026-09-05',
+    latestReadDate: '2026-09-06T10:00:00',
+    coverImage: 'cover.png',
+  } satisfies KavitaSeries;
+  const chapter = (
+    id: number,
+    pagesRead: number,
+    lastReadingProgressUtc: string,
+  ): KavitaSeriesDetail['chapters'][number] => ({
+    id,
+    title: `Book ${id}`,
+    titleName: `Book ${id}`,
+    volumeId: id,
+    pages: 20,
+    pagesRead,
+    summary: '',
+    format: 3,
+    files: [{ id, bytes: 1000, extension: '.epub', format: 3 }],
+    writers: [],
+    lastReadingProgressUtc,
+  });
+  const detail = {
+    chapters: [],
+    specials: [],
+    volumes: [
+      { id: 12, chapters: [chapter(120, 12, '2026-09-04T10:00:00')] },
+      { id: 13, chapters: [chapter(121, 0, '0001-01-01T00:00:00')] },
+    ],
+    storylineChapters: [],
+  } satisfies KavitaSeriesDetail;
+
+  expect(mapSeriesToBooks('primary', series, detail)).toMatchObject([
+    { chapterId: 120, pagesRead: 12, lastReadAt: '2026-09-04T10:00:00' },
+    { chapterId: 121, pagesRead: 0, lastReadAt: null },
+  ]);
+});
+
+it('falls back to aggregate progress only when chapter progress is absent', () => {
+  const series = {
+    id: 13,
+    name: 'Missing Progress',
+    libraryId: 1,
+    format: 3,
+    pages: 20,
+    pagesRead: 12,
+    created: '2026-09-05',
+    latestReadDate: '2026-09-06T10:00:00',
+    coverImage: 'cover.png',
+  } satisfies KavitaSeries;
+  const chapter = {
+    id: 130,
+    title: 'Book 130',
+    titleName: 'Book 130',
+    volumeId: 13,
+    pages: 20,
+    format: 3,
+    files: [{ id: 130, bytes: 1000, extension: '.epub', format: 3 }],
+    writers: [],
+    summary: '',
+  };
+  const detail = {
+    chapters: [],
+    specials: [],
+    volumes: [{ id: 13, chapters: [chapter] }],
+    storylineChapters: [],
+  } satisfies KavitaSeriesDetail;
+
+  expect(mapSeriesToBooks('primary', series, detail)[0]).toMatchObject({
+    pagesRead: 12,
+    lastReadAt: '2026-09-06T10:00:00',
+  });
+});

--- a/src/lib/kavita/mapper.ts
+++ b/src/lib/kavita/mapper.ts
@@ -8,14 +8,14 @@ export function mapSeriesToBooks(
   series: KavitaSeries,
   detail: KavitaSeriesDetail,
 ): BookRecord[] {
-  // Preserve the existing order before appending volume chapters. This keeps the
-  // old first-book id stable for records already stored locally, while still
-  // discovering books that Kavita nests under volumes.
+  // Keep flat arrays first so their representation wins if Kavita exposes the
+  // same chapter both flat and nested. IDs include the chapter ID, so existing
+  // local records remain matched regardless of this ordering.
   const chapters = [
     ...detail.chapters,
     ...detail.specials,
     ...detail.storylineChapters,
-    ...detail.volumes.flatMap((volume) => volume.chapters),
+    ...(detail.volumes ?? []).flatMap((volume) => volume.chapters),
   ];
   const seen = new Set<number>();
   return chapters
@@ -48,13 +48,18 @@ function mapChapterToBook(
     descriptionHtml: chapter.summary || null,
     format: 'epub',
     pages: chapter.pages || series.pages,
-    pagesRead: chapter.pagesRead || series.pagesRead,
+    pagesRead: chapter.pagesRead ?? series.pagesRead,
     createdAt: series.created,
-    lastReadAt: series.latestReadDate.startsWith(EMPTY_DATE) ? null : series.latestReadDate,
+    lastReadAt: lastReadAt(chapter, series),
     downloadPath: null,
     downloadStatus: 'none',
     fileSize: file.bytes,
   };
+}
+
+function lastReadAt(chapter: KavitaChapter, series: KavitaSeries): string | null {
+  const value = chapter.lastReadingProgressUtc ?? series.latestReadDate;
+  return !value || value.startsWith(EMPTY_DATE) ? null : value;
 }
 
 function isEpubChapter(chapter: KavitaChapter): boolean {

--- a/src/lib/kavita/mapper.ts
+++ b/src/lib/kavita/mapper.ts
@@ -3,16 +3,38 @@ import type { KavitaChapter, KavitaSeries, KavitaSeriesDetail } from './types';
 
 const EMPTY_DATE = '0001-01-01T00:00:00';
 
-export function mapSeriesToBook(
+export function mapSeriesToBooks(
   serverId: string,
   series: KavitaSeries,
   detail: KavitaSeriesDetail,
-): BookRecord | null {
-  const chapters = [...detail.chapters, ...detail.specials, ...detail.storylineChapters];
-  const chapter = chapters.find(isEpubChapter);
-  if (!chapter) return null;
+): BookRecord[] {
+  // Preserve the existing order before appending volume chapters. This keeps the
+  // old first-book id stable for records already stored locally, while still
+  // discovering books that Kavita nests under volumes.
+  const chapters = [
+    ...detail.chapters,
+    ...detail.specials,
+    ...detail.storylineChapters,
+    ...detail.volumes.flatMap((volume) => volume.chapters),
+  ];
+  const seen = new Set<number>();
+  return chapters
+    .filter(isEpubChapter)
+    .filter((chapter) => {
+      if (seen.has(chapter.id)) return false;
+      seen.add(chapter.id);
+      return true;
+    })
+    .map((chapter) => mapChapterToBook(serverId, series, chapter));
+}
+
+function mapChapterToBook(
+  serverId: string,
+  series: KavitaSeries,
+  chapter: KavitaChapter,
+): BookRecord {
   const file = chapter.files.find((item) => item.extension.toLowerCase() === '.epub');
-  if (!file) return null;
+  if (!file) throw new Error('An EPUB chapter did not include an EPUB file.');
   return {
     id: `${serverId}:${series.id}:${chapter.id}`,
     serverId,

--- a/src/lib/kavita/types.ts
+++ b/src/lib/kavita/types.ts
@@ -63,8 +63,14 @@ export interface KavitaChapter {
   lastReadingProgressUtc: string;
 }
 
+export interface KavitaVolume {
+  id: number;
+  chapters: KavitaChapter[];
+}
+
 export interface KavitaSeriesDetail {
   chapters: KavitaChapter[];
   specials: KavitaChapter[];
+  volumes: KavitaVolume[];
   storylineChapters: KavitaChapter[];
 }

--- a/src/lib/kavita/types.ts
+++ b/src/lib/kavita/types.ts
@@ -55,12 +55,12 @@ export interface KavitaChapter {
   titleName: string;
   volumeId: number;
   pages: number;
-  pagesRead: number;
+  pagesRead?: number;
   summary: string;
   format: number;
   files: KavitaFile[];
   writers: KavitaPerson[];
-  lastReadingProgressUtc: string;
+  lastReadingProgressUtc?: string | null;
 }
 
 export interface KavitaVolume {
@@ -71,6 +71,6 @@ export interface KavitaVolume {
 export interface KavitaSeriesDetail {
   chapters: KavitaChapter[];
   specials: KavitaChapter[];
-  volumes: KavitaVolume[];
+  volumes?: KavitaVolume[];
   storylineChapters: KavitaChapter[];
 }


### PR DESCRIPTION
## Problem

Kavita places many EPUB books under `SeriesDetailDto.volumes[].chapters[]`. Turnleaf only inspected the flat chapter and special arrays, so series-tagged and standalone books stored as volume entries were omitted from the library.

## What changed

- Model Kavita volume chapters in the series-detail response.
- Map every EPUB chapter in a series to its own local book record.
- Deduplicate chapters exposed in both flat and nested arrays.
- Preserve the existing flat-array order so current chapter IDs continue to match stored downloads and reading progress.
- Add regression coverage for volume-only series, specials, and duplicate chapter entries.

Fixes #34

## Validation

- `npm test`
- `npm run check`
- `npm run lint`
- `npm run format:check`
- `npm run build`
