### PR TITLE
Accept Kavita Light Novel libraries for EPUB reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Turnleaf is intentionally narrow in scope.
 
 Supported:
 
-- EPUB books
+- EPUB books in Kavita Book and Light Novel libraries, including books with illustrations
 - Text-first novels and long-form prose
 
 Not supported:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Allow EPUB accounts with Kavita Light Novel libraries to connect, including illustrated light novels.
+
 ## 0.2.0
 
 - Keep Kavita auth keys out of cover and download URLs by using authenticated headers for those requests.

--- a/src/lib/components/Library.svelte
+++ b/src/lib/components/Library.svelte
@@ -574,7 +574,9 @@
 
       const result = await new KavitaClient(server.baseUrl, nextKey).testConnection();
       if (result.bookLibraries.length === 0) {
-        throw new Error('This account has no book libraries. Only book libraries are supported.');
+        throw new Error(
+          'This account has no book or light novel libraries. Only EPUB books are supported.',
+        );
       }
 
       const updatedServer: ServerConfig = {

--- a/src/lib/components/Onboarding.svelte
+++ b/src/lib/components/Onboarding.svelte
@@ -29,7 +29,9 @@
 
       const result = await new KavitaClient(normalized.baseUrl, apiKey.trim()).testConnection();
       if (result.bookLibraries.length === 0) {
-        throw new Error('This account has no book libraries. Other media types are not supported.');
+        throw new Error(
+          'This account has no book or light novel libraries. Other media types are not supported.',
+        );
       }
 
       const id = 'primary';
@@ -127,7 +129,7 @@
         />
         <span class="label-text text-xs text-surface-800-200">
           Create this in Kavita for a dedicated non-administrator account with access only to the
-          book libraries you want on this device.
+          book or light novel libraries you want on this device.
         </span>
       </label>
 

--- a/src/lib/kavita/client.test.ts
+++ b/src/lib/kavita/client.test.ts
@@ -67,6 +67,34 @@ it('requests the Kavita series list with POST', async () => {
   );
 });
 
+it.each([[[2, 4]], [[4]]])(
+  'connects to supported EPUB library types %j',
+  async (supportedTypes) => {
+    const libraries = [...supportedTypes, 0, 1, 3, 5, 6].map((type, id) => ({
+      id,
+      name: `Library ${id}`,
+      type,
+    }));
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: { get: () => null },
+        json: async () => libraries,
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: { get: () => null },
+        json: async () => ({ version: 'test' }),
+      } as unknown as Response);
+
+    const result = await new KavitaClient('https://books.example.com', 'abc123').testConnection();
+
+    expect(result.bookLibraries.map((library) => library.type)).toEqual(supportedTypes);
+  },
+);
+
 it('retries a failed progress read once', async () => {
   const fetchMock = vi
     .fn()

--- a/src/lib/kavita/client.ts
+++ b/src/lib/kavita/client.ts
@@ -9,6 +9,7 @@ import type {
 
 const REQUEST_TIMEOUT_MS = 12_000;
 const BOOK_LIBRARY_TYPE = 2;
+const LIGHT_NOVEL_LIBRARY_TYPE = 4;
 const BROWSER_PROXY_PREFIX = '/__kavita__/';
 
 export class KavitaError extends Error {
@@ -39,7 +40,10 @@ export class KavitaClient {
     );
     return {
       version: health?.version ?? null,
-      bookLibraries: libraries.filter((library) => library.type === BOOK_LIBRARY_TYPE),
+      bookLibraries: libraries.filter(
+        (library) =>
+          library.type === BOOK_LIBRARY_TYPE || library.type === LIGHT_NOVEL_LIBRARY_TYPE,
+      ),
     };
   }
 


### PR DESCRIPTION
Accounts containing only Kavita Light Novel libraries were rejected before any EPUB was inspected. Accept Kavita's Book (2) and Light Novel (4) library types, update connection guidance, and document support for illustrated EPUBs.

Closes #35.

Validation: new connection regressions cover mixed Book/Light Novel accounts and Light Novel-only accounts while excluding unsupported library types. All 46 tests, type check, lint, formatting, and web build pass. The shared production-audit blocker is addressed separately by #54.
