### PR TITLE
Make native metadata refresh transactional

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Make native library metadata refreshes transactional so failed updates leave the saved library unchanged.
+
 ## 0.3.2
 
 - Generate clean GitHub release notes without npm command output.

--- a/src/lib/database/database.test.ts
+++ b/src/lib/database/database.test.ts
@@ -135,3 +135,12 @@ it('rolls back every metadata change when one task fails', async () => {
 
   expect(database.rows()).toEqual([existingBook]);
 });
+
+it('skips the native transaction when there is no metadata to refresh', async () => {
+  const database = createDatabase([]);
+
+  await replaceBooksInTransaction(database.db, 'server', []);
+
+  expect(database.executeTransaction).not.toHaveBeenCalled();
+  expect(database.rows()).toEqual([]);
+});

--- a/src/lib/database/database.test.ts
+++ b/src/lib/database/database.test.ts
@@ -1,0 +1,137 @@
+import { expect, it, vi } from 'vitest';
+import type { capSQLiteChanges, capTask } from '@capacitor-community/sqlite';
+import { replaceBooksInTransaction, type BookRecord } from './database';
+
+const existingBook: BookRecord = {
+  id: 'server:1:10',
+  serverId: 'server',
+  libraryId: 1,
+  seriesId: 1,
+  volumeId: 10,
+  chapterId: 10,
+  title: 'Old title',
+  author: 'Old author',
+  series: 'Old series',
+  descriptionHtml: '<p>Old description</p>',
+  format: 'epub',
+  pages: 100,
+  pagesRead: 25,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  lastReadAt: '2026-01-02T00:00:00.000Z',
+  downloadPath: 'books/server-1-10.epub',
+  downloadStatus: 'available',
+  fileSize: 1234,
+};
+
+const refreshedBook: BookRecord = {
+  ...existingBook,
+  title: 'New title',
+  author: 'New author',
+  series: 'New series',
+  descriptionHtml: '<p>New description</p>',
+  pages: 120,
+  pagesRead: 30,
+  lastReadAt: '2026-02-02T00:00:00.000Z',
+  downloadPath: null,
+  downloadStatus: 'none',
+  fileSize: 4321,
+};
+
+function createDatabase(initialRows: BookRecord[], failAt?: number) {
+  let rows = structuredClone(initialRows);
+  const executeTransaction = vi.fn(async (tasks: capTask[]): Promise<capSQLiteChanges> => {
+    const before = structuredClone(rows);
+    try {
+      tasks.forEach((task, index) => {
+        if (index === failAt) throw new Error('metadata write failed');
+        const values = task.values as unknown[];
+        const existing = rows.find((row) => row.id === values[0]);
+        if (existing) {
+          existing.title = String(values[6]);
+          existing.author = (values[7] as string | null) ?? null;
+          existing.series = (values[8] as string | null) ?? null;
+          existing.descriptionHtml = (values[9] as string | null) ?? null;
+          existing.format = String(values[10]);
+          existing.pages = Number(values[15]);
+          existing.pagesRead = Number(values[16]);
+          existing.createdAt = String(values[17]);
+          existing.lastReadAt = (values[18] as string | null) ?? null;
+          return;
+        }
+        rows.push({
+          id: String(values[0]),
+          serverId: String(values[1]),
+          libraryId: Number(values[2]),
+          seriesId: Number(values[3]),
+          volumeId: Number(values[4]),
+          chapterId: Number(values[5]),
+          title: String(values[6]),
+          author: (values[7] as string | null) ?? null,
+          series: (values[8] as string | null) ?? null,
+          descriptionHtml: (values[9] as string | null) ?? null,
+          format: String(values[10]),
+          pages: Number(values[15]),
+          pagesRead: Number(values[16]),
+          createdAt: String(values[17]),
+          lastReadAt: (values[18] as string | null) ?? null,
+          downloadPath: (values[12] as string | null) ?? null,
+          downloadStatus: String(values[13]),
+          fileSize: (values[14] as number | null) ?? null,
+        });
+      });
+    } catch (error) {
+      rows = before;
+      throw error;
+    }
+    return { changes: { changes: tasks.length } };
+  });
+
+  return {
+    db: { executeTransaction },
+    executeTransaction,
+    rows: () => rows,
+  };
+}
+
+it('commits metadata while preserving downloaded file state on existing books', async () => {
+  const database = createDatabase([existingBook]);
+
+  await replaceBooksInTransaction(
+    database.db,
+    'server',
+    [refreshedBook, { ...refreshedBook, id: 'server:1:11', chapterId: 11 }],
+    '2026-09-07T00:00:00.000Z',
+  );
+
+  expect(database.executeTransaction).toHaveBeenCalledOnce();
+  const tasks = database.executeTransaction.mock.calls[0]?.[0] ?? [];
+  expect(tasks).toHaveLength(2);
+  expect(tasks[0]?.statement).not.toContain('download_path=excluded');
+  expect(tasks[0]?.statement).not.toContain('server_id=excluded');
+  expect(tasks[0]?.statement).not.toContain('reading_state');
+  expect(database.rows()[0]).toMatchObject({
+    id: existingBook.id,
+    title: 'New title',
+    pagesRead: 30,
+    downloadPath: existingBook.downloadPath,
+    downloadStatus: existingBook.downloadStatus,
+    fileSize: existingBook.fileSize,
+    serverId: existingBook.serverId,
+  });
+  expect(database.rows()).toHaveLength(2);
+});
+
+it('rolls back every metadata change when one task fails', async () => {
+  const database = createDatabase([existingBook], 1);
+
+  await expect(
+    replaceBooksInTransaction(
+      database.db,
+      'server',
+      [refreshedBook, { ...refreshedBook, id: 'server:1:11', chapterId: 11 }],
+      '2026-09-07T00:00:00.000Z',
+    ),
+  ).rejects.toThrow('metadata write failed');
+
+  expect(database.rows()).toEqual([existingBook]);
+});

--- a/src/lib/database/database.ts
+++ b/src/lib/database/database.ts
@@ -275,6 +275,7 @@ export async function replaceBooksInTransaction(
   books: BookRecord[],
   refreshedAt = new Date().toISOString(),
 ): Promise<void> {
+  if (books.length === 0) return;
   await db.executeTransaction(books.map((book) => replaceBookTask(serverId, book, refreshedAt)));
 }
 

--- a/src/lib/database/database.ts
+++ b/src/lib/database/database.ts
@@ -2,6 +2,7 @@ import { Capacitor } from '@capacitor/core';
 import {
   CapacitorSQLite,
   SQLiteConnection,
+  type capTask,
   type SQLiteDBConnection,
 } from '@capacitor-community/sqlite';
 import { toKavitaPageNumber } from '../sync/conflict';
@@ -222,42 +223,59 @@ export async function replaceBooks(serverId: string, books: BookRecord[]): Promi
     writeBrowserState(state);
     return;
   }
-  const db = await openDatabase();
-  for (const book of books) {
-    await db.run(
-      `INSERT INTO books
-       (id, server_id, library_id, series_id, volume_id, chapter_id, title, author, series,
-        description_html, format, metadata_refreshed_at, download_path, download_status, file_size,
-        pages, pages_read, created_at, last_read_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-       ON CONFLICT(id) DO UPDATE SET
-        title=excluded.title, author=excluded.author, series=excluded.series,
-        description_html=excluded.description_html, format=excluded.format,
-        metadata_refreshed_at=excluded.metadata_refreshed_at, pages=excluded.pages,
-        pages_read=excluded.pages_read, created_at=excluded.created_at, last_read_at=excluded.last_read_at`,
-      [
-        book.id,
-        serverId,
-        book.libraryId,
-        book.seriesId,
-        book.volumeId,
-        book.chapterId,
-        book.title,
-        book.author,
-        book.series,
-        book.descriptionHtml,
-        book.format,
-        new Date().toISOString(),
-        book.downloadPath,
-        book.downloadStatus,
-        book.fileSize,
-        book.pages,
-        book.pagesRead,
-        book.createdAt,
-        book.lastReadAt,
-      ],
-    );
-  }
+  await replaceBooksInTransaction(await openDatabase(), serverId, books);
+}
+
+const replaceBookStatement = `INSERT INTO books
+  (id, server_id, library_id, series_id, volume_id, chapter_id, title, author, series,
+   description_html, format, metadata_refreshed_at, download_path, download_status, file_size,
+   pages, pages_read, created_at, last_read_at)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  ON CONFLICT(id) DO UPDATE SET
+   title=excluded.title, author=excluded.author, series=excluded.series,
+   description_html=excluded.description_html, format=excluded.format,
+   metadata_refreshed_at=excluded.metadata_refreshed_at, pages=excluded.pages,
+   pages_read=excluded.pages_read, created_at=excluded.created_at, last_read_at=excluded.last_read_at`;
+
+function replaceBookTask(serverId: string, book: BookRecord, refreshedAt: string): capTask {
+  return {
+    statement: replaceBookStatement,
+    values: [
+      book.id,
+      serverId,
+      book.libraryId,
+      book.seriesId,
+      book.volumeId,
+      book.chapterId,
+      book.title,
+      book.author,
+      book.series,
+      book.descriptionHtml,
+      book.format,
+      refreshedAt,
+      book.downloadPath,
+      book.downloadStatus,
+      book.fileSize,
+      book.pages,
+      book.pagesRead,
+      book.createdAt,
+      book.lastReadAt,
+    ],
+  };
+}
+
+/**
+ * Apply a native library refresh as one SQLite transaction. The UPSERT only
+ * changes metadata and progress columns on existing rows, leaving downloaded
+ * file columns and related reading/sync rows intact.
+ */
+export async function replaceBooksInTransaction(
+  db: Pick<SQLiteDBConnection, 'executeTransaction'>,
+  serverId: string,
+  books: BookRecord[],
+  refreshedAt = new Date().toISOString(),
+): Promise<void> {
+  await db.executeTransaction(books.map((book) => replaceBookTask(serverId, book, refreshedAt)));
 }
 
 export async function getBooks(serverId: string): Promise<BookRecord[]> {


### PR DESCRIPTION
## Summary

- Run native `replaceBooks` refreshes through the supported SQLite `executeTransaction` API.
- Keep the existing UPSERT behavior, including preservation of downloaded file columns, server identity, and related reading/sync rows for existing books.
- Add rollback and preservation coverage with a deterministic transaction mock.
- Document the change under `RELEASE_NOTES.md` Unreleased.

## Validation

- `npm run check`
- `npm run lint`
- `npm run format:check`
- `npm test` (11 files, 59 tests)
- `npm run build`
- `npm_config_ignore_scripts=true npm audit --omit=dev` (0 vulnerabilities)

`npm run android:debug` reached Gradle configuration but could not build because this environment has no configured Android SDK (`ANDROID_HOME`/`android/local.properties`). The repository `security:audit` wrapper is also blocked before invoking npm audit by the environment's project-scoped `EALLOWSCRIPTS` policy; the direct audit command above succeeds.

The transaction API is provided by `@capacitor-community/sqlite@8.1.0` (`SQLiteDBConnection.executeTransaction`), whose native/web implementations handle begin, commit, and rollback. No changes were made to browser storage behavior.
