### PR TITLE
Improve cover loading cancellation and concurrency

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Load library covers with bounded concurrency, cancel stale refresh work, and clean up browser cover URLs.
+
 ## 0.3.2
 
 - Generate clean GitHub release notes without npm command output.

--- a/src/lib/components/Library.svelte
+++ b/src/lib/components/Library.svelte
@@ -26,6 +26,7 @@
     downloadEpub,
     verifyDownloadedEpub,
   } from '../downloads/native-download';
+  import { loadCoversWithConcurrency } from '../downloads/cover-loader';
   import { KavitaClient } from '../kavita/client';
   import { mapSeriesToBooks } from '../kavita/mapper';
   import type { KavitaProgress } from '../kavita/types';
@@ -257,7 +258,10 @@
   const cleanups: Array<() => Promise<void>> = [];
   const nativePlatform = Capacitor.isNativePlatform();
   const SERIES_DETAIL_BATCH_SIZE = 8;
+  const COVER_LOAD_CONCURRENCY = 6;
   let destroyed = false;
+  let coverLoadController: AbortController | null = null;
+  let coverLoadGeneration = 0;
 
   function progressOf(book: BookRecord): number {
     return book.pages ? Math.min(100, (book.pagesRead / book.pages) * 100) : 0;
@@ -279,6 +283,7 @@
     pendingAutoSync = savedAutoSync === null ? true : savedAutoSync === 'true';
     books = await getBooks(server.id);
     if (destroyed) return;
+    retainCoversFor(books);
     void loadCovers(books);
     loading = false;
     offline = !(await Network.getStatus()).connected;
@@ -330,15 +335,15 @@
   onDestroy(() => {
     destroyed = true;
     if (syncTimer !== null) window.clearTimeout(syncTimer);
-    Object.values(covers)
-      .filter((cover) => cover.startsWith('blob:'))
-      .forEach(URL.revokeObjectURL);
+    cancelCoverLoading();
+    clearCovers();
     cleanups.forEach((remove) => void remove());
   });
 
   async function refresh(): Promise<void> {
     if (destroyed || refreshing) return;
     refreshing = true;
+    cancelCoverLoading();
     message = '';
     try {
       const series = await client.getBookSeries();
@@ -360,6 +365,7 @@
       await replaceBooks(server.id, mapped);
       if (destroyed) return;
       books = await getBooks(server.id);
+      retainCoversFor(books);
       void loadCovers(books);
       offline = false;
     } catch {
@@ -372,20 +378,66 @@
     }
   }
 
+  function cancelCoverLoading(): void {
+    coverLoadController?.abort();
+    coverLoadController = null;
+    coverLoadGeneration += 1;
+  }
+
+  function revokeBrowserCover(cover: string): void {
+    if (cover.startsWith('blob:')) URL.revokeObjectURL(cover);
+  }
+
+  function clearCovers(): void {
+    for (const cover of Object.values(covers)) revokeBrowserCover(cover);
+    covers = {};
+  }
+
+  function retainCoversFor(items: BookRecord[]): void {
+    const seriesIds = new Set(items.map((item) => item.seriesId));
+    const retained = Object.fromEntries(
+      Object.entries(covers).filter(([seriesId]) => seriesIds.has(Number(seriesId))),
+    );
+    for (const [seriesId, cover] of Object.entries(covers)) {
+      if (!seriesIds.has(Number(seriesId))) revokeBrowserCover(cover);
+    }
+    covers = retained;
+  }
+
   async function loadCovers(items: BookRecord[]): Promise<void> {
-    for (const book of items) {
-      if (covers[book.seriesId]) continue;
-      try {
-        const cover = nativePlatform
-          ? await cacheCover(client.coverUrl(book.seriesId), apiKey, book.seriesId)
-          : URL.createObjectURL(await client.getCover(book.seriesId));
-        covers = {
-          ...covers,
-          [book.seriesId]: cover,
-        };
-      } catch {
-        /* Metadata remains useful without decorative covers. */
-      }
+    if (destroyed) return;
+    cancelCoverLoading();
+    const controller = new AbortController();
+    const generation = coverLoadGeneration;
+    coverLoadController = controller;
+    try {
+      await loadCoversWithConcurrency(items, {
+        signal: controller.signal,
+        concurrency: COVER_LOAD_CONCURRENCY,
+        hasCover: (seriesId) => Boolean(covers[seriesId]),
+        load: async (seriesId, signal) => {
+          if (nativePlatform) {
+            return cacheCover(client.coverUrl(seriesId), apiKey, seriesId, signal);
+          }
+          const blob = await client.getCover(seriesId, signal);
+          if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
+          return URL.createObjectURL(blob);
+        },
+        onLoaded: (seriesId, cover) => {
+          if (destroyed || controller.signal.aborted || generation !== coverLoadGeneration) {
+            revokeBrowserCover(cover);
+            return;
+          }
+          const previous = covers[seriesId];
+          if (previous && previous !== cover) revokeBrowserCover(previous);
+          covers = {
+            ...covers,
+            [seriesId]: cover,
+          };
+        },
+      });
+    } finally {
+      if (coverLoadController === controller) coverLoadController = null;
     }
   }
 
@@ -569,8 +621,11 @@
   }
 
   async function clearCache(): Promise<void> {
+    cancelCoverLoading();
     await clearCoverCache();
-    covers = {};
+    if (destroyed) return;
+    clearCovers();
+    void loadCovers(books);
     message = 'Cover cache cleared.';
     settingsVisible = false;
   }
@@ -636,8 +691,9 @@
     deletingServer = true;
     try {
       for (const book of books.filter((item) => item.downloadPath)) await remove(book);
+      cancelCoverLoading();
       await clearCoverCache().catch(() => {});
-      covers = {};
+      clearCovers();
       await removeApiKey(server.credentialRef).catch(() => {});
       await removeServer(server.id);
       onServerDeleted();

--- a/src/lib/components/Library.svelte
+++ b/src/lib/components/Library.svelte
@@ -423,6 +423,7 @@
           if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
           return URL.createObjectURL(blob);
         },
+        dispose: revokeBrowserCover,
         onLoaded: (seriesId, cover) => {
           if (destroyed || controller.signal.aborted || generation !== coverLoadGeneration) {
             revokeBrowserCover(cover);

--- a/src/lib/downloads/cover-loader.test.ts
+++ b/src/lib/downloads/cover-loader.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { loadCoversWithConcurrency } from './cover-loader';
+
+describe('loadCoversWithConcurrency', () => {
+  it('deduplicates series and limits active loads', async () => {
+    const controller = new AbortController();
+    const loaded: number[] = [];
+    let active = 0;
+    let maximumActive = 0;
+
+    await loadCoversWithConcurrency(
+      [{ seriesId: 1 }, { seriesId: 1 }, { seriesId: 2 }, { seriesId: 3 }],
+      {
+        signal: controller.signal,
+        concurrency: 2,
+        load: async (seriesId) => {
+          active += 1;
+          maximumActive = Math.max(maximumActive, active);
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          active -= 1;
+          return seriesId;
+        },
+        onLoaded: (seriesId) => loaded.push(seriesId),
+      },
+    );
+
+    expect(maximumActive).toBe(2);
+    expect(loaded.sort()).toEqual([1, 2, 3]);
+  });
+
+  it('does not publish a cover that completes after cancellation', async () => {
+    const controller = new AbortController();
+    const loaded: number[] = [];
+    let resolveCover: ((seriesId: number) => void) | undefined;
+    const pendingCover = new Promise<number>((resolve) => {
+      resolveCover = resolve;
+    });
+
+    const loading = loadCoversWithConcurrency([{ seriesId: 7 }], {
+      signal: controller.signal,
+      load: async () => pendingCover,
+      onLoaded: (seriesId) => loaded.push(seriesId),
+    });
+
+    controller.abort();
+    resolveCover?.(7);
+    await loading;
+
+    expect(loaded).toEqual([]);
+  });
+
+  it('skips series that already have a cover', async () => {
+    const controller = new AbortController();
+    const requested: number[] = [];
+
+    await loadCoversWithConcurrency([{ seriesId: 1 }, { seriesId: 2 }], {
+      signal: controller.signal,
+      hasCover: (seriesId) => seriesId === 1,
+      load: async (seriesId) => {
+        requested.push(seriesId);
+        return seriesId;
+      },
+      onLoaded: () => {},
+    });
+
+    expect(requested).toEqual([2]);
+  });
+});

--- a/src/lib/downloads/cover-loader.test.ts
+++ b/src/lib/downloads/cover-loader.test.ts
@@ -31,6 +31,7 @@ describe('loadCoversWithConcurrency', () => {
   it('does not publish a cover that completes after cancellation', async () => {
     const controller = new AbortController();
     const loaded: number[] = [];
+    const disposed: number[] = [];
     let resolveCover: ((seriesId: number) => void) | undefined;
     const pendingCover = new Promise<number>((resolve) => {
       resolveCover = resolve;
@@ -40,6 +41,7 @@ describe('loadCoversWithConcurrency', () => {
       signal: controller.signal,
       load: async () => pendingCover,
       onLoaded: (seriesId) => loaded.push(seriesId),
+      dispose: (seriesId) => disposed.push(seriesId),
     });
 
     controller.abort();
@@ -47,6 +49,7 @@ describe('loadCoversWithConcurrency', () => {
     await loading;
 
     expect(loaded).toEqual([]);
+    expect(disposed).toEqual([7]);
   });
 
   it('skips series that already have a cover', async () => {

--- a/src/lib/downloads/cover-loader.ts
+++ b/src/lib/downloads/cover-loader.ts
@@ -1,0 +1,48 @@
+export interface CoverLoadItem {
+  seriesId: number;
+}
+
+export interface CoverLoaderOptions<T> {
+  signal: AbortSignal;
+  concurrency?: number;
+  hasCover?: (seriesId: number) => boolean;
+  load: (seriesId: number, signal: AbortSignal) => Promise<T>;
+  onLoaded: (seriesId: number, cover: T) => void;
+}
+
+/**
+ * Load a set of series covers with a small worker pool.
+ *
+ * The caller owns the signal and can cancel the whole batch when its view is
+ * torn down or replaced. Individual failures are ignored because covers are
+ * decorative and should not prevent the library metadata from rendering.
+ */
+export async function loadCoversWithConcurrency<T>(
+  items: readonly CoverLoadItem[],
+  { signal, concurrency = 6, hasCover, load, onLoaded }: CoverLoaderOptions<T>,
+): Promise<void> {
+  const seriesIds = [
+    ...new Set(items.map((item) => item.seriesId).filter((seriesId) => !hasCover?.(seriesId))),
+  ];
+  if (signal.aborted || seriesIds.length === 0) return;
+
+  const requestedConcurrency = Number.isFinite(concurrency) ? Math.floor(concurrency) : 1;
+  const workerCount = Math.min(Math.max(1, requestedConcurrency), seriesIds.length);
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    while (!signal.aborted) {
+      if (nextIndex >= seriesIds.length) return;
+      const seriesId = seriesIds[nextIndex++]!;
+
+      try {
+        const cover = await load(seriesId, signal);
+        if (!signal.aborted) onLoaded(seriesId, cover);
+      } catch {
+        if (signal.aborted) return;
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+}

--- a/src/lib/downloads/cover-loader.ts
+++ b/src/lib/downloads/cover-loader.ts
@@ -8,6 +8,7 @@ export interface CoverLoaderOptions<T> {
   hasCover?: (seriesId: number) => boolean;
   load: (seriesId: number, signal: AbortSignal) => Promise<T>;
   onLoaded: (seriesId: number, cover: T) => void;
+  dispose?: (cover: T) => void;
 }
 
 /**
@@ -19,7 +20,7 @@ export interface CoverLoaderOptions<T> {
  */
 export async function loadCoversWithConcurrency<T>(
   items: readonly CoverLoadItem[],
-  { signal, concurrency = 6, hasCover, load, onLoaded }: CoverLoaderOptions<T>,
+  { signal, concurrency = 6, hasCover, load, onLoaded, dispose }: CoverLoaderOptions<T>,
 ): Promise<void> {
   const seriesIds = [
     ...new Set(items.map((item) => item.seriesId).filter((seriesId) => !hasCover?.(seriesId))),
@@ -38,6 +39,7 @@ export async function loadCoversWithConcurrency<T>(
       try {
         const cover = await load(seriesId, signal);
         if (!signal.aborted) onLoaded(seriesId, cover);
+        else dispose?.(cover);
       } catch {
         if (signal.aborted) return;
       }

--- a/src/lib/downloads/native-download.ts
+++ b/src/lib/downloads/native-download.ts
@@ -85,19 +85,24 @@ export async function cacheCover(
   downloadUrl: string,
   apiKey: string,
   seriesId: number,
+  signal?: AbortSignal,
 ): Promise<string> {
+  if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
   const directory = 'covers';
   const path = `${directory}/${seriesId}.img`;
   await ensureDataDirectory(directory);
+  if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
   const existing = await Filesystem.getUri({ path, directory: Directory.Data });
   const valid = await Filesystem.stat({ path, directory: Directory.Data }).catch(() => null);
   if (!valid || valid.size === 0) {
+    if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
     await FileTransfer.downloadFile({
       url: downloadUrl,
       path: existing.uri,
       headers: { 'x-api-key': apiKey },
     });
   }
+  if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
   return Capacitor.convertFileSrc(existing.uri);
 }
 

--- a/src/lib/kavita/client.ts
+++ b/src/lib/kavita/client.ts
@@ -95,10 +95,13 @@ export class KavitaClient {
         readTimeout: REQUEST_TIMEOUT_MS,
       });
       this.assertStatus(response.status);
+      if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
       const encoded = String(response.data);
       const binary = atob(encoded.includes(',') ? (encoded.split(',').pop() ?? '') : encoded);
       const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
-      return new Blob([bytes]);
+      const blob = new Blob([bytes]);
+      if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
+      return blob;
     }
     const timeout = new AbortController();
     const timer = window.setTimeout(() => timeout.abort(), REQUEST_TIMEOUT_MS);


### PR DESCRIPTION
## Summary

- Load library covers through a bounded worker pool with duplicate series requests removed.
- Cancel cover batches when the component is destroyed, refreshed, or the cache is cleared, and ignore stale completions.
- Revoke browser object URLs when covers are replaced or discarded while keeping native cache requests authenticated.
- Add focused loader tests for concurrency, deduplication, cancellation, and existing-cover skips.

## Validation

- `npm run format:check`
- `npm run check`
- `npm test`
- `npm run lint`
- `npm run build`
- `npm_config_ignore_scripts=true npm audit --omit=dev`

`npm run android:debug` reached Gradle after Capacitor sync but could not continue because this environment has no Android SDK configured (`ANDROID_HOME` or `android/local.properties`).
