### PR TITLE
feat: virtualize large library lists

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Virtualize large library grids while preserving stable book ordering and touch scrolling.
+
 ## 0.3.2
 
 - Generate clean GitHub release notes without npm command output.

--- a/src/lib/components/Library.svelte
+++ b/src/lib/components/Library.svelte
@@ -35,6 +35,7 @@
   import { flushProgress } from '../sync/sync';
   import Reader from './Reader.svelte';
   import TurnleafLogo from './TurnleafLogo.svelte';
+  import { calculateVirtualWindow, type VirtualWindow } from './library-virtualization';
 
   const skeletonThemes = [
     'catppuccin',
@@ -253,10 +254,21 @@
   let deletingServer = $state(false);
   let confirmDeleteServer = $state(false);
   let actionMenuBook = $state<BookRecord | null>(null);
+  let libraryMain = $state<HTMLElement | null>(null);
+  let virtualGrid = $state<HTMLElement | null>(null);
+  let gridColumns = $state(2);
+  let rowHeight = $state(400);
+  let virtualWindow = $state<VirtualWindow>(calculateVirtualWindow(0, 2, 400, 0, 0));
+  let scrollTarget: HTMLElement | Window | null = null;
+  let virtualizationFrame: number | null = null;
   let syncTimer: number | null = null;
   const cleanups: Array<() => Promise<void>> = [];
   const nativePlatform = Capacitor.isNativePlatform();
   const SERIES_DETAIL_BATCH_SIZE = 8;
+  const VIRTUALIZATION_OVERSCAN_ROWS = 2;
+  const GRID_GAP_PX = 16;
+  const GRID_ROW_GAP_PX = 32;
+  const CARD_TEXT_HEIGHT_PX = 80;
   let destroyed = false;
 
   function progressOf(book: BookRecord): number {
@@ -267,7 +279,86 @@
     return server.baseUrl.toLowerCase().startsWith('http://');
   }
 
+  function columnsForWidth(width: number): number {
+    if (width >= 1024) return 5;
+    if (width >= 768) return 4;
+    if (width >= 640) return 3;
+    return 2;
+  }
+
+  function rowHeightFor(width: number, columns: number): number {
+    const cardWidth = Math.max(0, (width - (columns - 1) * GRID_GAP_PX) / columns);
+    return Math.max(1, Math.ceil(cardWidth * 1.5 + CARD_TEXT_HEIGHT_PX + GRID_ROW_GAP_PX));
+  }
+
+  function scheduleVirtualWindow(): void {
+    if (
+      destroyed ||
+      typeof window === 'undefined' ||
+      typeof window.requestAnimationFrame !== 'function' ||
+      virtualizationFrame !== null
+    ) {
+      return;
+    }
+    virtualizationFrame = window.requestAnimationFrame(() => {
+      virtualizationFrame = null;
+      updateVirtualWindow();
+    });
+  }
+
+  function updateVirtualWindow(): void {
+    if (destroyed || !virtualGrid) return;
+    const width = virtualGrid.clientWidth;
+    const nextColumns = width > 0 ? columnsForWidth(width) : gridColumns;
+    const nextRowHeight = width > 0 ? rowHeightFor(width, nextColumns) : rowHeight;
+    if (gridColumns !== nextColumns) gridColumns = nextColumns;
+    if (rowHeight !== nextRowHeight) rowHeight = nextRowHeight;
+
+    const gridRect = virtualGrid.getBoundingClientRect();
+    const scrollContainer = libraryMain?.closest<HTMLElement>('.app-stage');
+    if (scrollContainer) {
+      const containerRect = scrollContainer.getBoundingClientRect();
+      const listTop = gridRect.top - containerRect.top + scrollContainer.scrollTop;
+      virtualWindow = calculateVirtualWindow(
+        visibleBooks.length,
+        nextColumns,
+        nextRowHeight,
+        scrollContainer.scrollTop - listTop,
+        scrollContainer.clientHeight,
+        VIRTUALIZATION_OVERSCAN_ROWS,
+      );
+      return;
+    }
+    if (typeof window === 'undefined') return;
+    virtualWindow = calculateVirtualWindow(
+      visibleBooks.length,
+      nextColumns,
+      nextRowHeight,
+      -gridRect.top,
+      window.innerHeight,
+      VIRTUALIZATION_OVERSCAN_ROWS,
+    );
+  }
+
+  $effect(() => {
+    if (visibleBooks.length > 0) scheduleVirtualWindow();
+  });
+
+  $effect(() => {
+    if (!virtualGrid || typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(() => scheduleVirtualWindow());
+    observer.observe(virtualGrid);
+    scheduleVirtualWindow();
+    return () => observer.disconnect();
+  });
+
   onMount(async () => {
+    const scrollContainer = libraryMain?.closest<HTMLElement>('.app-stage');
+    scrollTarget = scrollContainer ?? window;
+    scrollTarget.addEventListener('scroll', scheduleVirtualWindow, { passive: true });
+    window.addEventListener('resize', scheduleVirtualWindow);
+    scheduleVirtualWindow();
+
     const savedTheme = await getPreference('uiTheme');
     if (destroyed) return;
     const savedMode = await getPreference('uiMode');
@@ -330,6 +421,9 @@
   onDestroy(() => {
     destroyed = true;
     if (syncTimer !== null) window.clearTimeout(syncTimer);
+    if (virtualizationFrame !== null) window.cancelAnimationFrame(virtualizationFrame);
+    scrollTarget?.removeEventListener('scroll', scheduleVirtualWindow);
+    window.removeEventListener('resize', scheduleVirtualWindow);
     Object.values(covers)
       .filter((cover) => cover.startsWith('blob:'))
       .forEach(URL.revokeObjectURL);
@@ -666,6 +760,7 @@
   />
 {:else}
   <main
+    bind:this={libraryMain}
     class="mx-auto min-h-full max-w-6xl px-4 pb-16 pt-[max(1.5rem,env(safe-area-inset-top))] sm:px-6"
   >
     <header class="flex items-center justify-between gap-4">
@@ -879,78 +974,92 @@
       </div>
     {:else}
       <section
-        class="mt-8 grid grid-cols-2 gap-x-4 gap-y-8 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5"
+        bind:this={virtualGrid}
+        class="relative mt-8"
+        style={`height: ${Math.max(0, virtualWindow.totalHeight - GRID_ROW_GAP_PX)}px`}
         aria-label="Books"
       >
-        {#each visibleBooks as book (book.id)}
-          <article class="relative text-left">
-            <button
-              class="group block w-full text-left"
-              type="button"
-              onclick={() => void open(book)}
-              oncontextmenu={(event) => {
-                event.preventDefault();
-                openMenu(book);
-              }}
-              disabled={downloadingBookId === book.id}
-            >
-              <div
-                class="preset-tonal-surface relative aspect-[2/3] overflow-hidden rounded-lg shadow-md transition-shadow duration-300 group-hover:shadow-xl"
-              >
-                {#if covers[book.seriesId]}
-                  <img
-                    class="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.04]"
-                    src={covers[book.seriesId]}
-                    loading="lazy"
-                    decoding="async"
-                    alt=""
-                  />
-                {/if}
-                {#if downloadingBookId === book.id}
-                  <span
-                    class="badge-icon preset-filled-primary-600-400 absolute left-2 top-2 h-7 w-7 p-0 shadow-md"
-                    title="Downloading"
-                    aria-label="Downloading"
+        {#each Array.from( { length: virtualWindow.lastRow - virtualWindow.firstRow + 1 } ) as _, rowOffset (rowOffset)}
+          {@const rowIndex = virtualWindow.firstRow + rowOffset}
+          {@const rowStart = rowIndex * gridColumns}
+          {@const rowEnd = Math.min(visibleBooks.length, rowStart + gridColumns)}
+          <div
+            class="absolute inset-x-0 grid gap-x-4"
+            style={`height: ${rowHeight}px; top: ${rowIndex * rowHeight}px; grid-template-columns: repeat(${gridColumns}, minmax(0, 1fr));`}
+          >
+            {#each visibleBooks.slice(rowStart, rowEnd) as book (book.id)}
+              <article class="relative text-left">
+                <button
+                  class="group block w-full text-left"
+                  type="button"
+                  onclick={() => void open(book)}
+                  oncontextmenu={(event) => {
+                    event.preventDefault();
+                    openMenu(book);
+                  }}
+                  disabled={downloadingBookId === book.id}
+                >
+                  <div
+                    class="preset-tonal-surface relative aspect-[2/3] overflow-hidden rounded-lg shadow-md transition-shadow duration-300 group-hover:shadow-xl"
                   >
-                    <svg aria-hidden="true" viewBox="0 0 24 24" class="h-4 w-4 animate-spin">
-                      <path
-                        fill="currentColor"
-                        d="M12 4V2a10 10 0 0 0-7.07 17.07l1.42-1.42A8 8 0 1 1 12 4Z"
+                    {#if covers[book.seriesId]}
+                      <img
+                        class="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.04]"
+                        src={covers[book.seriesId]}
+                        loading="lazy"
+                        decoding="async"
+                        alt=""
                       />
-                    </svg>
-                  </span>
-                {/if}
-                {#if progressOf(book) > 0}
-                  <div class="absolute inset-x-0 bottom-0 h-1.5">
-                    <div
-                      class="h-full preset-filled-primary-600-400"
-                      style:width={`${progressOf(book)}%`}
-                    ></div>
+                    {/if}
+                    {#if downloadingBookId === book.id}
+                      <span
+                        class="badge-icon preset-filled-primary-600-400 absolute left-2 top-2 h-7 w-7 p-0 shadow-md"
+                        title="Downloading"
+                        aria-label="Downloading"
+                      >
+                        <svg aria-hidden="true" viewBox="0 0 24 24" class="h-4 w-4 animate-spin">
+                          <path
+                            fill="currentColor"
+                            d="M12 4V2a10 10 0 0 0-7.07 17.07l1.42-1.42A8 8 0 1 1 12 4Z"
+                          />
+                        </svg>
+                      </span>
+                    {/if}
+                    {#if progressOf(book) > 0}
+                      <div class="absolute inset-x-0 bottom-0 h-1.5">
+                        <div
+                          class="h-full preset-filled-primary-600-400"
+                          style:width={`${progressOf(book)}%`}
+                        ></div>
+                      </div>
+                    {/if}
                   </div>
-                {/if}
-              </div>
-              <h2 class="mt-3 line-clamp-2 font-serif text-base leading-snug text-surface-950-50">
-                {book.title}
-              </h2>
-              <p class="mt-1 truncate text-sm text-surface-700-300">
-                {book.author ?? 'Unknown author'}
-              </p>
-            </button>
-            <button
-              class="btn btn-sm preset-tonal-tertiary absolute right-2 bottom-0 z-10 h-7 w-7 !p-0 shadow-md"
-              type="button"
-              onclick={() => openMenu(book)}
-              aria-label={`Book actions for ${book.title}`}
-              title="More actions"
-            >
-              <svg aria-hidden="true" viewBox="0 0 24 24" class="h-4 w-4">
-                <path
-                  fill="currentColor"
-                  d="M12 7a2 2 0 1 0 0-4 2 2 0 0 0 0 4Zm0 6a2 2 0 1 0 0-4 2 2 0 0 0 0 4Zm0 6a2 2 0 1 0 0-4 2 2 0 0 0 0 4Z"
-                />
-              </svg>
-            </button>
-          </article>
+                  <h2
+                    class="mt-3 line-clamp-2 font-serif text-base leading-snug text-surface-950-50"
+                  >
+                    {book.title}
+                  </h2>
+                  <p class="mt-1 truncate text-sm text-surface-700-300">
+                    {book.author ?? 'Unknown author'}
+                  </p>
+                </button>
+                <button
+                  class="btn btn-sm preset-tonal-tertiary absolute right-2 bottom-0 z-10 h-7 w-7 !p-0 shadow-md"
+                  type="button"
+                  onclick={() => openMenu(book)}
+                  aria-label={`Book actions for ${book.title}`}
+                  title="More actions"
+                >
+                  <svg aria-hidden="true" viewBox="0 0 24 24" class="h-4 w-4">
+                    <path
+                      fill="currentColor"
+                      d="M12 7a2 2 0 1 0 0-4 2 2 0 0 0 0 4Zm0 6a2 2 0 1 0 0-4 2 2 0 0 0 0 4Zm0 6a2 2 0 1 0 0-4 2 2 0 0 0 0 4Z"
+                    />
+                  </svg>
+                </button>
+              </article>
+            {/each}
+          </div>
         {/each}
       </section>
     {/if}

--- a/src/lib/components/library-virtualization.test.ts
+++ b/src/lib/components/library-virtualization.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { calculateVirtualWindow } from './library-virtualization';
+
+describe('calculateVirtualWindow', () => {
+  it('returns an empty window for an empty library', () => {
+    expect(calculateVirtualWindow(0, 2, 300, 0, 600)).toEqual({
+      firstRow: 0,
+      lastRow: -1,
+      startIndex: 0,
+      endIndex: 0,
+      totalRows: 0,
+      totalHeight: 0,
+    });
+  });
+
+  it('keeps the viewport and overscan within the available rows', () => {
+    expect(calculateVirtualWindow(25, 4, 100, 500, 200, 1)).toEqual({
+      firstRow: 4,
+      lastRow: 6,
+      startIndex: 16,
+      endIndex: 25,
+      totalRows: 7,
+      totalHeight: 700,
+    });
+  });
+
+  it('includes the final partial row without inventing items', () => {
+    expect(calculateVirtualWindow(5, 3, 240, 0, 1, 0)).toMatchObject({
+      firstRow: 0,
+      lastRow: 0,
+      startIndex: 0,
+      endIndex: 3,
+      totalRows: 2,
+      totalHeight: 480,
+    });
+    expect(calculateVirtualWindow(5, 3, 240, 300, 1, 0)).toMatchObject({
+      firstRow: 1,
+      lastRow: 1,
+      startIndex: 3,
+      endIndex: 5,
+    });
+  });
+
+  it('normalizes invalid dimensions and clamps negative scroll positions', () => {
+    expect(calculateVirtualWindow(3.9, 0, Number.NaN, -20, 100, -2)).toEqual({
+      firstRow: 0,
+      lastRow: 2,
+      startIndex: 0,
+      endIndex: 3,
+      totalRows: 3,
+      totalHeight: 3,
+    });
+  });
+});

--- a/src/lib/components/library-virtualization.ts
+++ b/src/lib/components/library-virtualization.ts
@@ -1,0 +1,54 @@
+export interface VirtualWindow {
+  firstRow: number;
+  lastRow: number;
+  startIndex: number;
+  endIndex: number;
+  totalRows: number;
+  totalHeight: number;
+}
+
+/**
+ * Select the rows that can intersect the viewport, plus a small buffer so a
+ * fast touch scroll does not reveal an empty row before the next frame.
+ */
+export function calculateVirtualWindow(
+  itemCount: number,
+  columnCount: number,
+  rowHeight: number,
+  scrollTop: number,
+  viewportHeight: number,
+  overscanRows = 2,
+): VirtualWindow {
+  const count = Math.max(0, Math.floor(Number.isFinite(itemCount) ? itemCount : 0));
+  const columns = Math.max(1, Math.floor(Number.isFinite(columnCount) ? columnCount : 1));
+  const height = Math.max(1, Number.isFinite(rowHeight) ? rowHeight : 1);
+  const overscan = Math.max(0, Math.floor(Number.isFinite(overscanRows) ? overscanRows : 0));
+  const totalRows = Math.ceil(count / columns);
+
+  if (totalRows === 0) {
+    return {
+      firstRow: 0,
+      lastRow: -1,
+      startIndex: 0,
+      endIndex: 0,
+      totalRows: 0,
+      totalHeight: 0,
+    };
+  }
+
+  const top = Math.max(0, Number.isFinite(scrollTop) ? scrollTop : 0);
+  const viewport = Math.max(0, Number.isFinite(viewportHeight) ? viewportHeight : 0);
+  const firstVisibleRow = Math.floor(top / height);
+  const lastVisibleRow = Math.floor(Math.max(top, top + viewport - 1) / height);
+  const firstRow = Math.max(0, firstVisibleRow - overscan);
+  const lastRow = Math.min(totalRows - 1, lastVisibleRow + overscan);
+
+  return {
+    firstRow,
+    lastRow,
+    startIndex: firstRow * columns,
+    endIndex: Math.min(count, (lastRow + 1) * columns),
+    totalRows,
+    totalHeight: totalRows * height,
+  };
+}


### PR DESCRIPTION
## What changed

Large libraries now render only the rows near the visible viewport. The library keeps a fixed-height virtual grid, tracks the existing `.app-stage` touch scroll container, and recalculates the responsive row window on scroll and resize. A small overscan buffer keeps fast mobile scrolling populated while the existing search, downloaded-only, completed, Continue Reading, action menus, keyboard/focus behavior, and stable filtered ordering remain unchanged.

The window calculation is dependency-free and covered by unit tests for empty lists, partial final rows, viewport boundaries, overscan, and invalid dimensions.

## Validation

- `npm run format`
- `npm run format:check`
- `npm run check`
- `npm test -- --run` (61 tests)
- `npm run lint`
- `npm run build`
- `npm audit --omit=dev --ignore-scripts` (0 vulnerabilities)
- `npm run android:debug` *(blocked after Capacitor sync because this environment has no Android SDK or `ANDROID_HOME`)*

Release notes were updated under `Unreleased`; the version was not changed.
