### PR TITLE
Add Android SDK preflight diagnostics

### DIFF
--- a/ANDROID_BUILD.md
+++ b/ANDROID_BUILD.md
@@ -13,6 +13,23 @@ Verified on Linux with the `turnleaf_api36` Google APIs x86_64 emulator: install
 
 ## Commands
 
+Check the local Android toolchain before starting a build. The preflight checks
+`android/local.properties`, `ANDROID_HOME`, `ANDROID_SDK_ROOT`, and the usual
+per-user SDK locations. It also verifies that the compile SDK (API 36) and at
+least one Android Build Tools version are installed.
+
+```bash
+npm run android:doctor
+```
+
+The project-specific `android/local.properties` file is intentionally ignored
+by Git because its path is machine-specific. Create it when the SDK is in a
+non-standard location, or export `ANDROID_HOME` instead:
+
+```bash
+printf 'sdk.dir=%s\n' "/absolute/path/to/Android/Sdk" > android/local.properties
+```
+
 ```bash
 export ANDROID_HOME="$HOME/Android/Sdk"
 export PATH="$ANDROID_HOME/platform-tools:$ANDROID_HOME/cmdline-tools/latest/bin:$PATH"

--- a/README.md
+++ b/README.md
@@ -177,9 +177,14 @@ Turnleaf has been tested on Android. The repo includes the Capacitor Android pro
 ```bash
 export ANDROID_HOME="$HOME/Android/Sdk"
 export PATH="$ANDROID_HOME/platform-tools:$ANDROID_HOME/cmdline-tools/latest/bin:$PATH"
+npm run android:doctor
 npm run cap:sync
 npm run android:debug
 ```
+
+`android:doctor` checks the SDK path, API 36, and Android Build Tools before a
+Gradle build. If the SDK is installed somewhere else, set `ANDROID_HOME` or
+create the ignored `android/local.properties` file with its absolute path.
 
 Useful follow-up commands:
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add an Android SDK preflight that explains missing local SDK configuration before Gradle builds.
 - Virtualize large library grids while preserving stable book ordering and touch scrolling.
 - Load library covers with bounded concurrency, cancel stale refresh work, and clean up browser cover URLs.
 - Make native library metadata refreshes transactional so failed updates leave the saved library unchanged.

--- a/package.json
+++ b/package.json
@@ -19,8 +19,9 @@
     "setup:hooks": "node scripts/install-githooks.mjs",
     "cap:sync": "npm run build && cap sync",
     "android:open": "export $(grep -v '^#' .env | xargs) && cap open android",
-    "android:debug": "npm run cap:sync && cd android && ./gradlew assembleDebug",
-    "android:release": "npm run build && npx cap sync android && cd android && ./gradlew assembleRelease",
+    "android:doctor": "node scripts/check-android-sdk.mjs",
+    "android:debug": "npm run android:doctor && npm run cap:sync && cd android && ./gradlew assembleDebug",
+    "android:release": "npm run android:doctor && npm run build && npx cap sync android && cd android && ./gradlew assembleRelease",
     "ios:sync": "npm run build && cap sync ios",
     "ios:open": "cap open ios",
     "postinstall": "node scripts/install-githooks.mjs"

--- a/scripts/check-android-sdk.mjs
+++ b/scripts/check-android-sdk.mjs
@@ -1,0 +1,158 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const ANDROID_PLATFORM = 'android-36';
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const projectRoot = dirname(scriptDirectory);
+const localPropertiesPath = join(projectRoot, 'android', 'local.properties');
+
+function readLocalProperties(path = localPropertiesPath) {
+  try {
+    return readFileSync(path, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+function unescapeProperty(value) {
+  return value.replace(/\\([\\:=])/g, '$1').trim();
+}
+
+export function parseSdkDir(contents) {
+  for (const line of contents.split(/\r?\n/)) {
+    if (line.trim().startsWith('#')) continue;
+    const match = /^\s*sdk\.dir\s*=(.*)$/.exec(line);
+    if (match?.[1]) return unescapeProperty(match[1]);
+  }
+  return null;
+}
+
+function addCandidate(candidates, value, source, baseDirectory) {
+  if (!value?.trim()) return;
+  const trimmed = value.trim();
+  const path = isAbsolute(trimmed) ? trimmed : resolve(baseDirectory, trimmed);
+  if (candidates.some((candidate) => candidate.path === path)) return;
+  candidates.push({ path, source });
+}
+
+export function sdkCandidates({
+  env = process.env,
+  home = homedir(),
+  platform = process.platform,
+  localPropertiesContents = readLocalProperties(),
+  localPropertiesDirectory = dirname(localPropertiesPath),
+} = {}) {
+  const candidates = [];
+  addCandidate(
+    candidates,
+    parseSdkDir(localPropertiesContents),
+    'android/local.properties',
+    localPropertiesDirectory,
+  );
+  addCandidate(candidates, env.ANDROID_HOME, 'ANDROID_HOME', home);
+  addCandidate(candidates, env.ANDROID_SDK_ROOT, 'ANDROID_SDK_ROOT', home);
+
+  if (platform === 'darwin') {
+    addCandidate(candidates, join(home, 'Library', 'Android', 'sdk'), 'macOS default', home);
+  } else if (platform === 'win32') {
+    if (env.LOCALAPPDATA) {
+      addCandidate(candidates, join(env.LOCALAPPDATA, 'Android', 'Sdk'), 'Windows default', home);
+    }
+    addCandidate(
+      candidates,
+      join(home, 'AppData', 'Local', 'Android', 'Sdk'),
+      'Windows default',
+      home,
+    );
+  } else {
+    addCandidate(candidates, join(home, 'Android', 'Sdk'), 'Linux default', home);
+  }
+
+  return candidates;
+}
+
+function defaultIsDirectory(path) {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function defaultReadDirectory(path) {
+  try {
+    return readdirSync(path);
+  } catch {
+    return [];
+  }
+}
+
+export function validateAndroidSdk(
+  candidates,
+  { isDirectory = defaultIsDirectory, readDirectory = defaultReadDirectory } = {},
+) {
+  const sdk = candidates.find((candidate) => isDirectory(candidate.path)) ?? null;
+  if (!sdk) {
+    return {
+      ok: false,
+      sdk: null,
+      missing: ['Android SDK'],
+      candidates,
+    };
+  }
+
+  const missing = [];
+  if (!isDirectory(join(sdk.path, 'platforms', ANDROID_PLATFORM))) {
+    missing.push(`Android SDK Platform ${ANDROID_PLATFORM.slice('android-'.length)}`);
+  }
+  const buildToolsPath = join(sdk.path, 'build-tools');
+  if (!isDirectory(buildToolsPath) || readDirectory(buildToolsPath).length === 0) {
+    missing.push('Android SDK Build Tools');
+  }
+
+  return {
+    ok: missing.length === 0,
+    sdk,
+    missing,
+    candidates,
+  };
+}
+
+export function formatFailure(result) {
+  const checked = result.candidates.map(
+    (candidate) => `  - ${candidate.path} (${candidate.source})`,
+  );
+  const lines = ['Android SDK setup is incomplete.'];
+  if (result.sdk) {
+    lines.push(`Found an SDK at ${result.sdk.path}, but it is missing:`);
+    lines.push(...result.missing.map((item) => `  - ${item}`));
+  } else {
+    lines.push('No Android SDK was found. Checked:');
+    lines.push(...checked);
+  }
+  lines.push(
+    '',
+    'Install Android Studio or the Android command-line tools, then set the SDK path:',
+    '  export ANDROID_HOME="$HOME/Android/Sdk"',
+    '  npm run android:doctor',
+    '',
+    'You can also configure this checkout with android/local.properties:',
+    '  printf \'sdk.dir=%s\\n\' "/absolute/path/to/Android/Sdk" > android/local.properties',
+  );
+  return lines.join('\n');
+}
+
+export function main() {
+  const result = validateAndroidSdk(sdkCandidates());
+  if (!result.ok) {
+    console.error(formatFailure(result));
+    process.exitCode = 1;
+    return;
+  }
+  console.log(`Android SDK ready at ${result.sdk.path} (${result.sdk.source}).`);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main();

--- a/scripts/check-android-sdk.test.mjs
+++ b/scripts/check-android-sdk.test.mjs
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatFailure,
+  parseSdkDir,
+  sdkCandidates,
+  validateAndroidSdk,
+} from './check-android-sdk.mjs';
+
+describe('Android SDK preflight', () => {
+  it('parses a project SDK path from local.properties', () => {
+    expect(parseSdkDir('# comment\nsdk.dir=/opt/android/sdk\n')).toBe('/opt/android/sdk');
+    expect(parseSdkDir('sdk.dir=C\\:\\Android\\Sdk')).toBe('C:\\Android\\Sdk');
+    expect(parseSdkDir('sdk.path=/wrong')).toBeNull();
+  });
+
+  it('prioritizes project configuration and removes duplicate candidates', () => {
+    const candidates = sdkCandidates({
+      env: { ANDROID_HOME: '/opt/android/sdk', ANDROID_SDK_ROOT: '/opt/android/sdk' },
+      home: '/home/tester',
+      platform: 'linux',
+      localPropertiesContents: 'sdk.dir=/opt/android/sdk\n',
+      localPropertiesDirectory: '/workspace/android',
+    });
+
+    expect(candidates).toEqual([
+      { path: '/opt/android/sdk', source: 'android/local.properties' },
+      { path: '/home/tester/Android/Sdk', source: 'Linux default' },
+    ]);
+  });
+
+  it('requires the compile SDK platform and at least one build-tools version', () => {
+    const candidates = [{ path: '/sdk', source: 'ANDROID_HOME' }];
+    const installed = new Set(['/sdk', '/sdk/platforms/android-36', '/sdk/build-tools']);
+    const result = validateAndroidSdk(candidates, {
+      isDirectory: (path) => installed.has(path),
+      readDirectory: () => ['36.0.0'],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.sdk).toEqual(candidates[0]);
+    expect(result.missing).toEqual([]);
+  });
+
+  it('reports actionable guidance when the SDK is missing', () => {
+    const result = validateAndroidSdk([{ path: '/missing/sdk', source: 'ANDROID_HOME' }], {
+      isDirectory: () => false,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(formatFailure(result)).toContain('ANDROID_HOME');
+    expect(formatFailure(result)).toContain('android/local.properties');
+  });
+});


### PR DESCRIPTION
## Summary

- Add an `android:doctor` preflight for local Android SDK configuration.
- Run the preflight before debug and release Gradle builds.
- Detect project, environment, and platform-default SDK paths and validate API 36 plus Android Build Tools.
- Add tests and document the setup flow.

## Validation

- `npm run format:check`
- `npm run check`
- `npm run lint`
- `npm test -- --run` (71 tests)
- `npm run build`
- `npm_config_ignore_scripts=true npm audit --omit=dev`
- `npm run android:debug`

Also configured the local environment with `ANDROID_HOME=/home/steven/Android/Sdk` and the ignored `android/local.properties` SDK path.
