### PR TITLE
fix: make local data recovery retry first

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@
 - Virtualize large library grids while preserving stable book ordering and touch scrolling.
 - Load library covers with bounded concurrency, cancel stale refresh work, and clean up browser cover URLs.
 - Make native library metadata refreshes transactional so failed updates leave the saved library unchanged.
+- Add a retry-first local-data recovery path with an explicit reset warning that preserves downloaded EPUB files.
 
 ## 0.3.2
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -29,7 +29,9 @@
   let uiMode = $state<'light' | 'dark'>(defaultMode);
   let releaseBanner = $state<ReleaseBanner | null>(null);
 
-  onMount(async () => {
+  async function loadLocalData(): Promise<void> {
+    booting = true;
+    startupError = '';
     void checkForRelease();
     try {
       const saved = await getServer();
@@ -42,10 +44,15 @@
         if (apiKey) server = saved;
       }
     } catch {
-      startupError = 'Local data could not be opened. Your downloaded books were not changed.';
+      startupError =
+        'Turnleaf could not open its local data. Retry first; resetting is a last resort and clears saved reading progress and settings.';
     } finally {
       booting = false;
     }
+  }
+
+  onMount(() => {
+    void loadLocalData();
   });
 
   async function repairLocalData(): Promise<void> {
@@ -53,8 +60,10 @@
     startupError = '';
     try {
       await resetLocalDatabase();
+      startupError = '';
     } catch {
-      startupError = 'Local data could not be reset. Try reinstalling the app.';
+      startupError =
+        'Local data could not be reset. Your downloaded EPUB files were left in place; try again or reinstall the app.';
       return;
     } finally {
       repairing = false;
@@ -166,8 +175,24 @@
             <button
               class="btn btn-sm preset-filled-error-500 !text-sm"
               type="button"
+              onclick={() => void loadLocalData()}
               disabled={repairing}
-              onclick={repairLocalData}
+            >
+              Retry
+            </button>
+            <button
+              class="btn btn-sm preset-tonal-error !text-sm"
+              type="button"
+              disabled={repairing}
+              onclick={() => {
+                if (
+                  window.confirm(
+                    'Reset local data? This clears saved reading progress, settings, and server configuration. Downloaded EPUB files stay on this device but may need to be downloaded again.',
+                  )
+                ) {
+                  void repairLocalData();
+                }
+              }}
             >
               {repairing ? 'Resetting...' : 'Reset local data'}
             </button>


### PR DESCRIPTION
## Summary
- retry local database startup before offering destructive repair
- explain the data and downloaded EPUB consequences before resetting local state
- preserve downloaded EPUB files and provide a clear recovery message if reset fails

## Validation
- `npm run check`
- `npm test -- --run`
