### PR TITLE
Make native reading persistence transactional

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@
 - Virtualize large library grids while preserving stable book ordering and touch scrolling.
 - Load library covers with bounded concurrency, cancel stale refresh work, and clean up browser cover URLs.
 - Make native library metadata refreshes transactional so failed updates leave the saved library unchanged.
+- Make native reading progress, completion, sync acknowledgement, and migrations transactional.
 
 ## 0.3.2
 

--- a/src/lib/database/database.native.test.ts
+++ b/src/lib/database/database.native.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, expect, it, vi } from 'vitest';
+import type { capSQLiteChanges, capTask } from '@capacitor-community/sqlite';
+
+const mocks = vi.hoisted(() => {
+  let databaseVersion = 3;
+  const executeTransaction = vi.fn<(tasks: capTask[]) => Promise<capSQLiteChanges>>(async () => ({
+    changes: { changes: 0 },
+  }));
+  const db = {
+    close: vi.fn(async () => undefined),
+    execute: vi.fn(async () => ({ changes: { changes: 0 } })),
+    executeTransaction,
+    getVersion: vi.fn(async () => ({ version: databaseVersion })),
+    open: vi.fn(async () => undefined),
+    query: vi.fn(async () => ({ values: [] })),
+    run: vi.fn(async () => ({ changes: { changes: 1 } })),
+  };
+  const sqlite = {
+    checkConnectionsConsistency: vi.fn(async () => ({ result: true })),
+    createConnection: vi.fn(async () => db),
+    isConnection: vi.fn(async () => ({ result: false })),
+  };
+  return {
+    db,
+    executeTransaction,
+    reset() {
+      databaseVersion = 3;
+      vi.clearAllMocks();
+    },
+    setDatabaseVersion(version: number) {
+      databaseVersion = version;
+    },
+    sqlite,
+  };
+});
+
+vi.mock('@capacitor/core', () => ({
+  Capacitor: {
+    isNativePlatform: () => true,
+  },
+}));
+
+vi.mock('@capacitor-community/sqlite', () => ({
+  CapacitorSQLite: {
+    deleteDatabase: vi.fn(async () => undefined),
+  },
+  SQLiteConnection: class {
+    constructor() {
+      return mocks.sqlite;
+    }
+  },
+}));
+
+const book = {
+  id: 'server:1:10',
+  serverId: 'server',
+  libraryId: 1,
+  seriesId: 1,
+  volumeId: 10,
+  chapterId: 10,
+  title: 'Book',
+  author: null,
+  series: null,
+  descriptionHtml: null,
+  format: 'epub',
+  pages: 100,
+  pagesRead: 0,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  lastReadAt: null,
+  downloadPath: null,
+  downloadStatus: 'none',
+  fileSize: null,
+};
+
+const readingState = {
+  cfi: 'epubcfi(/6/2)',
+  xpath: '/html/body/p[1]',
+  percentage: 0.4,
+  localUpdatedAt: '2026-01-01T00:00:00.000Z',
+  serverUpdatedAt: null,
+  pendingSync: false,
+};
+
+beforeEach(() => {
+  mocks.reset();
+});
+
+it('groups progress, queue, and book updates into one native transaction', async () => {
+  const { saveLocalProgress } = await import('./database');
+
+  await saveLocalProgress(book, readingState.cfi, readingState.xpath, 0.4, 2);
+
+  expect(mocks.executeTransaction).toHaveBeenCalledOnce();
+  const [tasks] = mocks.executeTransaction.mock.calls[0] ?? [];
+  expect(tasks).toHaveLength(3);
+  expect(tasks?.map((task) => task.statement)).toEqual([
+    expect.stringContaining('INSERT INTO reading_state'),
+    expect.stringContaining('INSERT INTO sync_queue'),
+    expect.stringContaining('UPDATE books'),
+  ]);
+});
+
+it('keeps a failed native progress transaction atomic', async () => {
+  const persisted = { book: false, readingState: false, syncQueue: false };
+  mocks.executeTransaction.mockImplementationOnce(async (tasks: capTask[]) => {
+    const before = { ...persisted };
+    try {
+      tasks.forEach((task, index) => {
+        if (index === 1) throw new Error('queue write failed');
+        if (task.statement.includes('reading_state')) persisted.readingState = true;
+        if (task.statement.includes('books')) persisted.book = true;
+        if (task.statement.includes('sync_queue')) persisted.syncQueue = true;
+      });
+    } catch (error) {
+      Object.assign(persisted, before);
+      throw error;
+    }
+    return { changes: { changes: tasks.length } };
+  });
+
+  const { saveLocalProgress } = await import('./database');
+  await expect(saveLocalProgress(book, readingState.cfi, readingState.xpath, 0.4)).rejects.toThrow(
+    'queue write failed',
+  );
+
+  expect(persisted).toEqual({ book: false, readingState: false, syncQueue: false });
+  expect(mocks.executeTransaction).toHaveBeenCalledOnce();
+});
+
+it('groups completion and acknowledgement writes separately', async () => {
+  const { confirmSync, markBookCompleted } = await import('./database');
+
+  await markBookCompleted(book, readingState);
+  await confirmSync(book.id, '2026-01-02T00:00:00.000Z');
+
+  expect(mocks.executeTransaction).toHaveBeenCalledTimes(2);
+  const [completionTasks, acknowledgementTasks] = mocks.executeTransaction.mock.calls;
+  expect(completionTasks?.[0]).toHaveLength(3);
+  expect(acknowledgementTasks?.[0]).toHaveLength(2);
+  expect(acknowledgementTasks?.[0]?.map((task) => task.statement)).toEqual([
+    expect.stringContaining('DELETE FROM sync_queue'),
+    expect.stringContaining('UPDATE reading_state'),
+  ]);
+});
+
+it('records each migration and its user version in one transaction', async () => {
+  const { openDatabase, resetLocalDatabase } = await import('./database');
+  await resetLocalDatabase();
+  mocks.setDatabaseVersion(0);
+  mocks.executeTransaction.mockClear();
+
+  await openDatabase();
+
+  expect(mocks.executeTransaction).toHaveBeenCalledTimes(3);
+  const migrationTasks = mocks.executeTransaction.mock.calls.map(([tasks]) => tasks);
+  expect(migrationTasks.map((tasks) => tasks?.[0]?.statement)).toEqual([
+    expect.stringContaining('CREATE TABLE IF NOT EXISTS server_config'),
+    expect.stringContaining('ALTER TABLE books ADD COLUMN pages'),
+    expect.stringContaining('CREATE TABLE preferences'),
+  ]);
+  expect(migrationTasks.map((tasks) => tasks?.[1]?.statement)).toEqual([
+    'PRAGMA user_version = 1;',
+    'PRAGMA user_version = 2;',
+    'PRAGMA user_version = 3;',
+  ]);
+});

--- a/src/lib/database/database.ts
+++ b/src/lib/database/database.ts
@@ -151,8 +151,10 @@ async function migrate(db: SQLiteDBConnection): Promise<void> {
   const current = await db.getVersion();
   for (const migration of migrations) {
     if (migration.version <= (current.version ?? 0)) continue;
-    await db.execute(migration.statements, true);
-    await db.execute(`PRAGMA user_version = ${migration.version};`);
+    await db.executeTransaction([
+      { statement: migration.statements },
+      { statement: `PRAGMA user_version = ${migration.version};` },
+    ]);
   }
 }
 
@@ -345,6 +347,41 @@ export interface PendingProgressPayload {
   bookScrollId?: string | null;
 }
 
+const readingStateUpsertStatement = `INSERT INTO reading_state
+  (book_id,cfi,kavita_xpath,percentage,local_updated_at,pending_sync)
+  VALUES (?,?,?,?,?,1) ON CONFLICT(book_id) DO UPDATE SET cfi=excluded.cfi,
+  kavita_xpath=excluded.kavita_xpath,percentage=excluded.percentage,
+  local_updated_at=excluded.local_updated_at,pending_sync=1`;
+
+const syncQueueUpsertStatement = `INSERT INTO sync_queue
+  (book_id,payload_json,created_at,updated_at) VALUES (?,?,?,?)
+  ON CONFLICT(book_id) DO UPDATE SET payload_json=excluded.payload_json,
+  updated_at=excluded.updated_at`;
+
+function createReadingStateTask(
+  bookId: string,
+  cfi: string,
+  xpath: string | null,
+  percentage: number,
+  updatedAt: string,
+): capTask {
+  return {
+    statement: readingStateUpsertStatement,
+    values: [bookId, cfi, xpath, percentage, updatedAt],
+  };
+}
+
+function createSyncQueueTask(
+  bookId: string,
+  payload: PendingProgressPayload,
+  updatedAt: string,
+): capTask {
+  return {
+    statement: syncQueueUpsertStatement,
+    values: [bookId, JSON.stringify(payload), updatedAt, updatedAt],
+  };
+}
+
 export async function getReadingState(bookId: string): Promise<StoredReadingState | null> {
   if (!Capacitor.isNativePlatform()) {
     return readBrowserState().readingState[bookId] ?? null;
@@ -418,23 +455,13 @@ export async function saveLocalProgress(
     pageNum: pagesRead,
     bookScrollId: xpath,
   };
-  await db.run(
-    `INSERT INTO reading_state (book_id,cfi,kavita_xpath,percentage,local_updated_at,pending_sync)
-    VALUES (?,?,?,?,?,1) ON CONFLICT(book_id) DO UPDATE SET cfi=excluded.cfi,
-    kavita_xpath=excluded.kavita_xpath,percentage=excluded.percentage,
-    local_updated_at=excluded.local_updated_at,pending_sync=1`,
-    [book.id, cfi, xpath, percentage, now],
-  );
-  await db.run(
-    `INSERT INTO sync_queue (book_id,payload_json,created_at,updated_at) VALUES (?,?,?,?)
-    ON CONFLICT(book_id) DO UPDATE SET payload_json=excluded.payload_json,
-    updated_at=excluded.updated_at`,
-    [book.id, JSON.stringify(payload), now, now],
-  );
-  await db.run('UPDATE books SET pages_read=?, last_read_at=? WHERE id=?', [
-    pagesRead,
-    now,
-    book.id,
+  await db.executeTransaction([
+    createReadingStateTask(book.id, cfi, xpath, percentage, now),
+    createSyncQueueTask(book.id, payload, now),
+    {
+      statement: 'UPDATE books SET pages_read=?, last_read_at=? WHERE id=?',
+      values: [pagesRead, now, book.id],
+    },
   ]);
 }
 
@@ -483,26 +510,17 @@ export async function markBookCompleted(
     return;
   }
   const db = await openDatabase();
-  await db.run('UPDATE books SET pages_read=?, last_read_at=? WHERE id=?', [
-    book.pages,
-    now,
-    book.id,
-  ]);
+  const tasks: capTask[] = [
+    {
+      statement: 'UPDATE books SET pages_read=?, last_read_at=? WHERE id=?',
+      values: [book.pages, now, book.id],
+    },
+  ];
   if (readingState) {
-    await db.run(
-      `INSERT INTO reading_state (book_id,cfi,kavita_xpath,percentage,local_updated_at,pending_sync)
-      VALUES (?,?,?,?,?,1) ON CONFLICT(book_id) DO UPDATE SET cfi=excluded.cfi,
-      kavita_xpath=excluded.kavita_xpath,percentage=excluded.percentage,
-      local_updated_at=excluded.local_updated_at,pending_sync=1`,
-      [book.id, readingState.cfi, readingState.xpath, 1, now],
-    );
+    tasks.push(createReadingStateTask(book.id, readingState.cfi, readingState.xpath, 1, now));
   }
-  await db.run(
-    `INSERT INTO sync_queue (book_id,payload_json,created_at,updated_at) VALUES (?,?,?,?)
-    ON CONFLICT(book_id) DO UPDATE SET payload_json=excluded.payload_json,
-    updated_at=excluded.updated_at`,
-    [book.id, JSON.stringify(payload), now, now],
-  );
+  tasks.push(createSyncQueueTask(book.id, payload, now));
+  await db.executeTransaction(tasks);
 }
 
 export async function getPendingSync(): Promise<Array<{ bookId: string; payload: string }>> {
@@ -534,12 +552,14 @@ export async function confirmSync(bookId: string, serverUpdatedAt: string): Prom
     return;
   }
   const db = await openDatabase();
-  await db.run('DELETE FROM sync_queue WHERE book_id=?', [bookId]);
-  await db.run(
-    `UPDATE reading_state SET pending_sync=0,synced_local_updated_at=local_updated_at,
-    server_updated_at=? WHERE book_id=?`,
-    [serverUpdatedAt, bookId],
-  );
+  await db.executeTransaction([
+    { statement: 'DELETE FROM sync_queue WHERE book_id=?', values: [bookId] },
+    {
+      statement: `UPDATE reading_state SET pending_sync=0,synced_local_updated_at=local_updated_at,
+      server_updated_at=? WHERE book_id=?`,
+      values: [serverUpdatedAt, bookId],
+    },
+  ]);
 }
 
 export async function markSyncFailure(bookId: string, error: string): Promise<void> {


### PR DESCRIPTION
## Summary
- group native local progress, completion, and sync acknowledgement writes into SQLite transactions
- apply each schema migration and its `user_version` update atomically
- add native transaction grouping and rollback coverage

## Validation
- `npm run check`
- `npm run lint -- --max-warnings=0`
- `npm run format:check`
- `npm test`
- `npm run build`
- `npm audit --omit=dev --ignore-scripts`
