### PR TITLE
Preserve newer local progress during sync acknowledgement

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Preserve newer local reading progress when an older sync upload completes.
 - Add an Android SDK preflight that explains missing local SDK configuration before Gradle builds.
 - Virtualize large library grids while preserving stable book ordering and touch scrolling.
 - Load library covers with bounded concurrency, cancel stale refresh work, and clean up browser cover URLs.

--- a/src/lib/database/database.native.test.ts
+++ b/src/lib/database/database.native.test.ts
@@ -131,15 +131,15 @@ it('groups completion and acknowledgement writes separately', async () => {
   const { confirmSync, markBookCompleted } = await import('./database');
 
   await markBookCompleted(book, readingState);
-  await confirmSync(book.id, '2026-01-02T00:00:00.000Z');
+  await confirmSync(book.id, '2026-01-02T00:00:00.000Z', readingState.localUpdatedAt);
 
   expect(mocks.executeTransaction).toHaveBeenCalledTimes(2);
   const [completionTasks, acknowledgementTasks] = mocks.executeTransaction.mock.calls;
   expect(completionTasks?.[0]).toHaveLength(3);
   expect(acknowledgementTasks?.[0]).toHaveLength(2);
   expect(acknowledgementTasks?.[0]?.map((task) => task.statement)).toEqual([
-    expect.stringContaining('DELETE FROM sync_queue'),
     expect.stringContaining('UPDATE reading_state'),
+    expect.stringContaining('DELETE FROM sync_queue'),
   ]);
 });
 

--- a/src/lib/database/database.test.ts
+++ b/src/lib/database/database.test.ts
@@ -1,6 +1,36 @@
 import { expect, it, vi } from 'vitest';
 import type { capSQLiteChanges, capTask } from '@capacitor-community/sqlite';
-import { replaceBooksInTransaction, type BookRecord } from './database';
+import { confirmSync, replaceBooksInTransaction, type BookRecord } from './database';
+
+const BROWSER_STORAGE_KEY = 'turnleaf_browser_database_v1';
+
+class MemoryStorage implements Storage {
+  private readonly values = new Map<string, string>();
+
+  get length(): number {
+    return this.values.size;
+  }
+
+  clear(): void {
+    this.values.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  key(index: number): string | null {
+    return [...this.values.keys()][index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+}
 
 const existingBook: BookRecord = {
   id: 'server:1:10',
@@ -143,4 +173,42 @@ it('skips the native transaction when there is no metadata to refresh', async ()
 
   expect(database.executeTransaction).not.toHaveBeenCalled();
   expect(database.rows()).toEqual([]);
+});
+
+it('does not acknowledge a queue item that was replaced while it uploaded', async () => {
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: new MemoryStorage(),
+  });
+  const state = {
+    serverConfig: null,
+    books: [],
+    readingState: {
+      'book-1': {
+        cfi: 'cfi',
+        xpath: null,
+        percentage: 0.5,
+        localUpdatedAt: '2026-09-07T00:00:01.000Z',
+        serverUpdatedAt: null,
+        pendingSync: true,
+      },
+    },
+    syncQueue: {
+      'book-1': {
+        bookId: 'book-1',
+        payloadJson: '{"pageNum":2}',
+        attemptCount: 0,
+        lastAttemptAt: null,
+        lastError: null,
+        createdAt: '2026-09-07T00:00:01.000Z',
+        updatedAt: '2026-09-07T00:00:01.000Z',
+      },
+    },
+    preferences: {},
+  };
+  localStorage.setItem(BROWSER_STORAGE_KEY, JSON.stringify(state));
+
+  await confirmSync('book-1', '2026-09-07T00:00:02.000Z', '2026-09-07T00:00:00.000Z');
+
+  expect(JSON.parse(localStorage.getItem(BROWSER_STORAGE_KEY) ?? '{}')).toEqual(state);
 });

--- a/src/lib/database/database.ts
+++ b/src/lib/database/database.ts
@@ -548,16 +548,18 @@ export async function confirmSync(
     return;
   }
   const db = await openDatabase();
-  const result = await db.run('DELETE FROM sync_queue WHERE book_id=? AND updated_at=?', [
-    bookId,
-    expectedUpdatedAt,
+  await db.executeTransaction([
+    {
+      statement: `UPDATE reading_state SET pending_sync=0,synced_local_updated_at=local_updated_at,
+        server_updated_at=? WHERE book_id=? AND local_updated_at=?
+        AND EXISTS (SELECT 1 FROM sync_queue WHERE book_id=? AND updated_at=?)`,
+      values: [serverUpdatedAt, bookId, expectedUpdatedAt, bookId, expectedUpdatedAt],
+    },
+    {
+      statement: 'DELETE FROM sync_queue WHERE book_id=? AND updated_at=?',
+      values: [bookId, expectedUpdatedAt],
+    },
   ]);
-  if ((result.changes?.changes ?? 0) === 0) return;
-  await db.run(
-    `UPDATE reading_state SET pending_sync=0,synced_local_updated_at=local_updated_at,
-    server_updated_at=? WHERE book_id=? AND local_updated_at=?`,
-    [serverUpdatedAt, bookId, expectedUpdatedAt],
-  );
 }
 
 export async function markSyncFailure(bookId: string, error: string): Promise<void> {

--- a/src/lib/database/database.ts
+++ b/src/lib/database/database.ts
@@ -505,23 +505,37 @@ export async function markBookCompleted(
   );
 }
 
-export async function getPendingSync(): Promise<Array<{ bookId: string; payload: string }>> {
+export interface PendingSyncItem {
+  bookId: string;
+  payload: string;
+  updatedAt: string;
+}
+
+export async function getPendingSync(): Promise<PendingSyncItem[]> {
   if (!Capacitor.isNativePlatform()) {
     return Object.values(readBrowserState().syncQueue)
       .sort((a, b) => a.updatedAt.localeCompare(b.updatedAt))
-      .map((row) => ({ bookId: row.bookId, payload: row.payloadJson }));
+      .map((row) => ({ bookId: row.bookId, payload: row.payloadJson, updatedAt: row.updatedAt }));
   }
   const db = await openDatabase();
-  const result = await db.query('SELECT book_id,payload_json FROM sync_queue ORDER BY updated_at');
+  const result = await db.query(
+    'SELECT book_id,payload_json,updated_at FROM sync_queue ORDER BY updated_at',
+  );
   return (result.values ?? []).map((row) => ({
     bookId: String(row.book_id),
     payload: String(row.payload_json),
+    updatedAt: String(row.updated_at),
   }));
 }
 
-export async function confirmSync(bookId: string, serverUpdatedAt: string): Promise<void> {
+export async function confirmSync(
+  bookId: string,
+  serverUpdatedAt: string,
+  expectedUpdatedAt: string,
+): Promise<void> {
   if (!Capacitor.isNativePlatform()) {
     const state = readBrowserState();
+    if (state.syncQueue[bookId]?.updatedAt !== expectedUpdatedAt) return;
     delete state.syncQueue[bookId];
     if (state.readingState[bookId]) {
       state.readingState[bookId] = {
@@ -534,11 +548,15 @@ export async function confirmSync(bookId: string, serverUpdatedAt: string): Prom
     return;
   }
   const db = await openDatabase();
-  await db.run('DELETE FROM sync_queue WHERE book_id=?', [bookId]);
+  const result = await db.run('DELETE FROM sync_queue WHERE book_id=? AND updated_at=?', [
+    bookId,
+    expectedUpdatedAt,
+  ]);
+  if ((result.changes?.changes ?? 0) === 0) return;
   await db.run(
     `UPDATE reading_state SET pending_sync=0,synced_local_updated_at=local_updated_at,
-    server_updated_at=? WHERE book_id=?`,
-    [serverUpdatedAt, bookId],
+    server_updated_at=? WHERE book_id=? AND local_updated_at=?`,
+    [serverUpdatedAt, bookId, expectedUpdatedAt],
   );
 }
 

--- a/src/lib/sync/sync.test.ts
+++ b/src/lib/sync/sync.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, expect, it, vi } from 'vitest';
+import { flushProgress } from './sync';
+
+const STORAGE_KEY = 'turnleaf_browser_database_v1';
+
+class MemoryStorage implements Storage {
+  private readonly values = new Map<string, string>();
+
+  get length(): number {
+    return this.values.size;
+  }
+
+  clear(): void {
+    this.values.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  key(index: number): string | null {
+    return [...this.values.keys()][index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+}
+
+const pendingState = (updatedAt: string, payloadJson: string) => ({
+  serverConfig: null,
+  books: [],
+  readingState: {
+    'book-1': {
+      cfi: 'cfi',
+      xpath: null,
+      percentage: payloadJson.includes('2') ? 0.2 : 0.1,
+      localUpdatedAt: updatedAt,
+      serverUpdatedAt: null,
+      pendingSync: true,
+    },
+  },
+  syncQueue: {
+    'book-1': {
+      bookId: 'book-1',
+      payloadJson,
+      attemptCount: 0,
+      lastAttemptAt: null,
+      lastError: null,
+      createdAt: updatedAt,
+      updatedAt,
+    },
+  },
+  preferences: {},
+});
+
+beforeEach(() => {
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: new MemoryStorage(),
+  });
+  localStorage.clear();
+});
+
+it('keeps a newer local queue item when an older upload completes', async () => {
+  let resolveUploaded!: () => void;
+  const uploaded = new Promise<void>((resolve) => {
+    resolveUploaded = resolve;
+  });
+  const first = pendingState('2026-09-07T00:00:00.000Z', '{"pageNum":1}');
+  const second = pendingState('2026-09-07T00:00:01.000Z', '{"pageNum":2}');
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(first));
+
+  const saveProgress = vi.fn(async () => uploaded);
+  const flush = flushProgress({ saveProgress } as never);
+  await vi.waitFor(() => expect(saveProgress).toHaveBeenCalledOnce());
+
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(second));
+  resolveUploaded();
+  await flush;
+
+  const saved = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}') as typeof second;
+  expect(saved.syncQueue['book-1']).toEqual(second.syncQueue['book-1']);
+  expect(saved.readingState['book-1']?.pendingSync).toBe(true);
+});

--- a/src/lib/sync/sync.ts
+++ b/src/lib/sync/sync.ts
@@ -14,7 +14,7 @@ async function run(client: KavitaClient): Promise<void> {
   for (const item of await getPendingSync()) {
     try {
       await client.saveProgress(JSON.parse(item.payload) as KavitaProgress);
-      await confirmSync(item.bookId, new Date().toISOString());
+      await confirmSync(item.bookId, new Date().toISOString(), item.updatedAt);
     } catch (error) {
       await markSyncFailure(item.bookId, error instanceof Error ? error.message : 'Sync failed');
       throw error;


### PR DESCRIPTION
## Problem
A progress upload can finish after a newer local update replaces its queue entry. The old acknowledgement then deleted the newer entry and marked that reading state as synced.

## Change
- Include the queue update timestamp in pending sync snapshots.
- Delete and mark reading state synced only when the acknowledged timestamp is still current.
- Add a browser regression test covering delayed upload A followed by local update B.

## Validation
- `npm test`
- `npm run check`
- `npm run lint`
- `npm run format:check`
