### PR TITLE
fix: preserve focus in virtualized library windows

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@
 - Virtualize large library grids while preserving stable book ordering and touch scrolling.
 - Load library covers with bounded concurrency, cancel stale refresh work, and clean up browser cover URLs.
 - Make native library metadata refreshes transactional so failed updates leave the saved library unchanged.
+- Keep virtualized library windows valid at the end of long lists and preserve focused books while scrolling.
 
 ## 0.3.2
 

--- a/src/lib/components/Library.svelte
+++ b/src/lib/components/Library.svelte
@@ -323,25 +323,48 @@
     if (scrollContainer) {
       const containerRect = scrollContainer.getBoundingClientRect();
       const listTop = gridRect.top - containerRect.top + scrollContainer.scrollTop;
-      virtualWindow = calculateVirtualWindow(
-        visibleBooks.length,
-        nextColumns,
-        nextRowHeight,
-        scrollContainer.scrollTop - listTop,
-        scrollContainer.clientHeight,
-        VIRTUALIZATION_OVERSCAN_ROWS,
+      virtualWindow = preserveFocusedRow(
+        calculateVirtualWindow(
+          visibleBooks.length,
+          nextColumns,
+          nextRowHeight,
+          scrollContainer.scrollTop - listTop,
+          scrollContainer.clientHeight,
+          VIRTUALIZATION_OVERSCAN_ROWS,
+        ),
       );
       return;
     }
     if (typeof window === 'undefined') return;
-    virtualWindow = calculateVirtualWindow(
-      visibleBooks.length,
-      nextColumns,
-      nextRowHeight,
-      -gridRect.top,
-      window.innerHeight,
-      VIRTUALIZATION_OVERSCAN_ROWS,
+    virtualWindow = preserveFocusedRow(
+      calculateVirtualWindow(
+        visibleBooks.length,
+        nextColumns,
+        nextRowHeight,
+        -gridRect.top,
+        window.innerHeight,
+        VIRTUALIZATION_OVERSCAN_ROWS,
+      ),
     );
+  }
+
+  function preserveFocusedRow(next: VirtualWindow): VirtualWindow {
+    if (next.totalRows === 0 || typeof document === 'undefined') return next;
+    const activeBookId =
+      document.activeElement?.closest<HTMLElement>('[data-book-id]')?.dataset.bookId;
+    if (!activeBookId) return next;
+    const bookIndex = visibleBooks.findIndex((book) => book.id === activeBookId);
+    if (bookIndex < 0) return next;
+    const focusedRow = Math.floor(bookIndex / gridColumns);
+    const firstRow = Math.min(next.firstRow, focusedRow);
+    const lastRow = Math.max(next.lastRow, focusedRow);
+    return {
+      ...next,
+      firstRow,
+      lastRow,
+      startIndex: firstRow * gridColumns,
+      endIndex: Math.min(visibleBooks.length, (lastRow + 1) * gridColumns),
+    };
   }
 
   $effect(() => {
@@ -1045,7 +1068,7 @@
             style={`height: ${rowHeight}px; top: ${rowIndex * rowHeight}px; grid-template-columns: repeat(${gridColumns}, minmax(0, 1fr));`}
           >
             {#each visibleBooks.slice(rowStart, rowEnd) as book (book.id)}
-              <article class="relative text-left">
+              <article class="relative text-left" data-book-id={book.id}>
                 <button
                   class="group block w-full text-left"
                   type="button"

--- a/src/lib/components/library-virtualization.test.ts
+++ b/src/lib/components/library-virtualization.test.ts
@@ -51,4 +51,15 @@ describe('calculateVirtualWindow', () => {
       totalHeight: 3,
     });
   });
+
+  it('keeps a valid final row when scrolling past the end', () => {
+    expect(calculateVirtualWindow(5, 2, 100, 50_000, 800, 2)).toEqual({
+      firstRow: 0,
+      lastRow: 2,
+      startIndex: 0,
+      endIndex: 5,
+      totalRows: 3,
+      totalHeight: 300,
+    });
+  });
 });

--- a/src/lib/components/library-virtualization.ts
+++ b/src/lib/components/library-virtualization.ts
@@ -38,10 +38,13 @@ export function calculateVirtualWindow(
 
   const top = Math.max(0, Number.isFinite(scrollTop) ? scrollTop : 0);
   const viewport = Math.max(0, Number.isFinite(viewportHeight) ? viewportHeight : 0);
-  const firstVisibleRow = Math.floor(top / height);
-  const lastVisibleRow = Math.floor(Math.max(top, top + viewport - 1) / height);
+  const firstVisibleRow = Math.min(totalRows - 1, Math.floor(top / height));
+  const lastVisibleRow = Math.min(
+    totalRows - 1,
+    Math.floor(Math.max(top, top + viewport - 1) / height),
+  );
   const firstRow = Math.max(0, firstVisibleRow - overscan);
-  const lastRow = Math.min(totalRows - 1, lastVisibleRow + overscan);
+  const lastRow = Math.max(firstRow, Math.min(totalRows - 1, lastVisibleRow + overscan));
 
   return {
     firstRow,


### PR DESCRIPTION
## Summary
- clamp virtual windows when scroll positions overshoot the final row
- keep the focused book row mounted while the user scrolls a large library
- cover the end-of-list regression with a focused unit test

## Validation
- `npm run check`
- `npm test -- --run`
