### PR TITLE
Harden Android SDK preflight handoff

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -46,17 +46,11 @@ jobs:
           echo "TURNLEAF_VERSION_CODE=${GITHUB_RUN_NUMBER}" >> "$GITHUB_ENV"
           echo "TURNLEAF_RELEASE_TAG=v${RELEASE_VERSION}" >> "$GITHUB_ENV"
 
-      - name: Build web assets
-        run: npm run build
-
       - name: Finalize release notes
         run: npm run release:finalize
 
       - name: Prepare release notes
         run: npm run --silent release:notes > "$RUNNER_TEMP/turnleaf-release-notes.md"
-
-      - name: Sync Android project
-        run: npx cap sync android
 
       - name: Restore signing key
         env:
@@ -91,7 +85,7 @@ jobs:
           EOF
 
       - name: Build signed release APK
-        run: cd android && ./gradlew assembleRelease
+        run: npm run android:release
 
       - name: Publish GitHub release
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,5 @@ jobs:
       - name: Run tests
         run: npm test
 
-      - name: Build web app
-        run: npm run build
-
-      - name: Sync Android project
-        run: npx cap sync android
-
       - name: Build Android debug APK
-        run: cd android && ./gradlew assembleDebug
+        run: npm run android:debug

--- a/README.md
+++ b/README.md
@@ -178,13 +178,14 @@ Turnleaf has been tested on Android. The repo includes the Capacitor Android pro
 export ANDROID_HOME="$HOME/Android/Sdk"
 export PATH="$ANDROID_HOME/platform-tools:$ANDROID_HOME/cmdline-tools/latest/bin:$PATH"
 npm run android:doctor
-npm run cap:sync
 npm run android:debug
 ```
 
-`android:doctor` checks the SDK path, API 36, and Android Build Tools before a
-Gradle build. If the SDK is installed somewhere else, set `ANDROID_HOME` or
-create the ignored `android/local.properties` file with its absolute path.
+`android:doctor` checks the SDK path, API 36, Android Build Tools, and Java 17+
+before a Gradle build. `android:debug` and `android:release` repeat that check,
+then pass the selected SDK path to both Capacitor sync and Gradle. If the SDK is
+installed somewhere else, set `ANDROID_HOME` or create the ignored
+`android/local.properties` file with its absolute path.
 
 Useful follow-up commands:
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@
 - Virtualize large library grids while preserving stable book ordering and touch scrolling.
 - Load library covers with bounded concurrency, cancel stale refresh work, and clean up browser cover URLs.
 - Make native library metadata refreshes transactional so failed updates leave the saved library unchanged.
+- Propagate the resolved Android SDK to Capacitor and Gradle builds, validate installed packages and Java compatibility, and report actionable preflight failures.
 
 ## 0.3.2
 

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "cap:sync": "npm run build && cap sync",
     "android:open": "export $(grep -v '^#' .env | xargs) && cap open android",
     "android:doctor": "node scripts/check-android-sdk.mjs",
-    "android:debug": "npm run android:doctor && npm run cap:sync && cd android && ./gradlew assembleDebug",
-    "android:release": "npm run android:doctor && npm run build && npx cap sync android && cd android && ./gradlew assembleRelease",
+    "android:debug": "node scripts/android-build.mjs debug",
+    "android:release": "node scripts/android-build.mjs release",
     "ios:sync": "npm run build && cap sync ios",
     "ios:open": "cap open ios",
     "postinstall": "node scripts/install-githooks.mjs"

--- a/scripts/android-build.mjs
+++ b/scripts/android-build.mjs
@@ -1,0 +1,94 @@
+import { spawn } from 'node:child_process';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  detectJavaCompatibility,
+  formatFailure,
+  formatJavaFailure,
+  sdkCandidates,
+  validateAndroidSdk,
+} from './check-android-sdk.mjs';
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const projectRoot = dirname(scriptDirectory);
+const androidDirectory = join(projectRoot, 'android');
+
+export function childEnvironment(sdkPath, environment = process.env) {
+  return {
+    ...environment,
+    ANDROID_HOME: sdkPath,
+    ANDROID_SDK_ROOT: sdkPath,
+  };
+}
+
+export function gradleTask(mode) {
+  if (mode === 'debug') return 'assembleDebug';
+  if (mode === 'release') return 'assembleRelease';
+  throw new Error(`Unsupported Android build mode: ${mode}`);
+}
+
+export function runCommand(command, args, options = {}) {
+  return new Promise((resolveCommand, rejectCommand) => {
+    const child = spawn(command, args, {
+      ...options,
+      shell: process.platform === 'win32',
+      stdio: 'inherit',
+    });
+
+    child.once('error', rejectCommand);
+    child.once('exit', (code, signal) => {
+      if (code === 0) {
+        resolveCommand();
+        return;
+      }
+
+      const error = new Error(
+        signal ? `${command} terminated by ${signal}` : `${command} exited with code ${code}`,
+      );
+      error.exitCode = code ?? 1;
+      rejectCommand(error);
+    });
+  });
+}
+
+export async function main(mode = process.argv[2]) {
+  let task;
+  try {
+    task = gradleTask(mode);
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+    return;
+  }
+
+  const sdk = validateAndroidSdk(sdkCandidates());
+  if (!sdk.ok) {
+    console.error(formatFailure(sdk));
+    process.exitCode = 1;
+    return;
+  }
+
+  const java = detectJavaCompatibility();
+  if (!java.ok) {
+    console.error(formatJavaFailure(java));
+    process.exitCode = 1;
+    return;
+  }
+
+  const env = childEnvironment(sdk.sdk.path);
+  const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+  const gradle = process.platform === 'win32' ? 'gradlew.bat' : './gradlew';
+  console.log(`Using Android SDK at ${sdk.sdk.path} for Capacitor and Gradle.`);
+
+  try {
+    await runCommand(npm, ['run', 'cap:sync'], { cwd: projectRoot, env });
+    await runCommand(gradle, [task], { cwd: androidDirectory, env });
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = error.exitCode ?? 1;
+  }
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/scripts/check-android-sdk.mjs
+++ b/scripts/check-android-sdk.mjs
@@ -1,9 +1,13 @@
+import { spawnSync } from 'node:child_process';
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, isAbsolute, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 export const ANDROID_PLATFORM = 'android-36';
+export const MIN_JAVA_MAJOR = 17;
+
+const BUILD_TOOLS_VERSION = /^\d+\.\d+\.\d+(?:[-.][0-9A-Za-z]+)*$/;
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const projectRoot = dirname(scriptDirectory);
@@ -90,12 +94,35 @@ function defaultReadDirectory(path) {
   }
 }
 
+export function buildToolsVersions(
+  sdkPath,
+  { isDirectory = defaultIsDirectory, readDirectory = defaultReadDirectory } = {},
+) {
+  const buildToolsPath = join(sdkPath, 'build-tools');
+  if (!isDirectory(buildToolsPath)) return [];
+
+  return readDirectory(buildToolsPath).filter(
+    (entry) => BUILD_TOOLS_VERSION.test(entry) && isDirectory(join(buildToolsPath, entry)),
+  );
+}
+
+function missingPackages(sdkPath, { isDirectory, readDirectory }) {
+  const missing = [];
+  if (!isDirectory(join(sdkPath, 'platforms', ANDROID_PLATFORM))) {
+    missing.push(`Android SDK Platform ${ANDROID_PLATFORM.slice('android-'.length)}`);
+  }
+  if (buildToolsVersions(sdkPath, { isDirectory, readDirectory }).length === 0) {
+    missing.push('Android SDK Build Tools');
+  }
+  return missing;
+}
+
 export function validateAndroidSdk(
   candidates,
   { isDirectory = defaultIsDirectory, readDirectory = defaultReadDirectory } = {},
 ) {
-  const sdk = candidates.find((candidate) => isDirectory(candidate.path)) ?? null;
-  if (!sdk) {
+  const existingCandidates = candidates.filter((candidate) => isDirectory(candidate.path));
+  if (existingCandidates.length === 0) {
     return {
       ok: false,
       sdk: null,
@@ -104,20 +131,55 @@ export function validateAndroidSdk(
     };
   }
 
-  const missing = [];
-  if (!isDirectory(join(sdk.path, 'platforms', ANDROID_PLATFORM))) {
-    missing.push(`Android SDK Platform ${ANDROID_PLATFORM.slice('android-'.length)}`);
+  const packageOptions = { isDirectory, readDirectory };
+  const sdk = existingCandidates.find(
+    (candidate) => missingPackages(candidate.path, packageOptions).length === 0,
+  );
+  if (sdk) {
+    return {
+      ok: true,
+      sdk,
+      missing: [],
+      candidates,
+    };
   }
-  const buildToolsPath = join(sdk.path, 'build-tools');
-  if (!isDirectory(buildToolsPath) || readDirectory(buildToolsPath).length === 0) {
-    missing.push('Android SDK Build Tools');
-  }
+
+  const firstExisting = existingCandidates[0];
+  const missing = missingPackages(firstExisting.path, packageOptions);
 
   return {
     ok: missing.length === 0,
-    sdk,
+    sdk: firstExisting,
     missing,
     candidates,
+  };
+}
+
+export function parseJavaMajor(versionOutput) {
+  const version = /version\s+"([^"]+)"/.exec(versionOutput)?.[1];
+  if (!version) return null;
+
+  const parts = version.split(/[._-]/).map(Number);
+  if (!Number.isInteger(parts[0])) return null;
+  return parts[0] === 1 ? (parts[1] ?? null) : parts[0];
+}
+
+export function validateJavaCompatibility(javaMajor, minimum = MIN_JAVA_MAJOR) {
+  return {
+    ok: Number.isInteger(javaMajor) && javaMajor >= minimum,
+    major: javaMajor,
+    minimum,
+  };
+}
+
+export function detectJavaCompatibility({ run = spawnSync } = {}) {
+  const result = run('java', ['-version'], { encoding: 'utf8' });
+  const output = `${result.stdout ?? ''}\n${result.stderr ?? ''}`;
+  const major = parseJavaMajor(output);
+  return {
+    ...validateJavaCompatibility(major),
+    output,
+    error: result.error ?? null,
   };
 }
 
@@ -145,6 +207,22 @@ export function formatFailure(result) {
   return lines.join('\n');
 }
 
+export function formatJavaFailure(result) {
+  if (result.major === null) {
+    return [
+      'Java setup is incomplete or could not be detected.',
+      'Android builds require a working Java installation (JDK 17 or newer).',
+      'Install a supported JDK and ensure `java` is available on PATH.',
+    ].join('\n');
+  }
+
+  return [
+    `Java ${result.major} is too old for the Android Gradle plugin.`,
+    `Android builds require Java ${result.minimum} or newer.`,
+    'Install a supported JDK and ensure `java` is available on PATH.',
+  ].join('\n');
+}
+
 export function main() {
   const result = validateAndroidSdk(sdkCandidates());
   if (!result.ok) {
@@ -152,7 +230,19 @@ export function main() {
     process.exitCode = 1;
     return;
   }
-  console.log(`Android SDK ready at ${result.sdk.path} (${result.sdk.source}).`);
+
+  const java = detectJavaCompatibility();
+  if (!java.ok) {
+    console.error(formatJavaFailure(java));
+    process.exitCode = 1;
+    return;
+  }
+
+  const versions = buildToolsVersions(result.sdk.path);
+  console.log(
+    `Android SDK ready at ${result.sdk.path} (${result.sdk.source}); ` +
+      `platform ${ANDROID_PLATFORM}, build tools ${versions.join(', ')}, Java ${java.major}.`,
+  );
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main();

--- a/scripts/check-android-sdk.test.mjs
+++ b/scripts/check-android-sdk.test.mjs
@@ -1,10 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import {
+  buildToolsVersions,
+  detectJavaCompatibility,
   formatFailure,
+  formatJavaFailure,
   parseSdkDir,
+  parseJavaMajor,
   sdkCandidates,
+  validateJavaCompatibility,
   validateAndroidSdk,
 } from './check-android-sdk.mjs';
+import { childEnvironment, gradleTask } from './android-build.mjs';
 
 describe('Android SDK preflight', () => {
   it('parses a project SDK path from local.properties', () => {
@@ -30,7 +36,12 @@ describe('Android SDK preflight', () => {
 
   it('requires the compile SDK platform and at least one build-tools version', () => {
     const candidates = [{ path: '/sdk', source: 'ANDROID_HOME' }];
-    const installed = new Set(['/sdk', '/sdk/platforms/android-36', '/sdk/build-tools']);
+    const installed = new Set([
+      '/sdk',
+      '/sdk/platforms/android-36',
+      '/sdk/build-tools',
+      '/sdk/build-tools/36.0.0',
+    ]);
     const result = validateAndroidSdk(candidates, {
       isDirectory: (path) => installed.has(path),
       readDirectory: () => ['36.0.0'],
@@ -41,6 +52,67 @@ describe('Android SDK preflight', () => {
     expect(result.missing).toEqual([]);
   });
 
+  it('ignores malformed or empty SDK candidates before selecting a complete SDK', () => {
+    const directories = new Set([
+      '/empty',
+      '/empty/platforms',
+      '/empty/build-tools',
+      '/complete',
+      '/complete/platforms',
+      '/complete/platforms/android-36',
+      '/complete/build-tools',
+      '/complete/build-tools/36.0.0',
+    ]);
+    const entries = new Map([
+      ['/empty/build-tools', []],
+      ['/complete/build-tools', ['README.txt', 'latest', '36.0.0']],
+    ]);
+    const result = validateAndroidSdk(
+      [
+        { path: '/empty', source: 'android/local.properties' },
+        { path: '/complete', source: 'ANDROID_HOME' },
+      ],
+      {
+        isDirectory: (path) => directories.has(path),
+        readDirectory: (path) => entries.get(path) ?? [],
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.sdk).toEqual({ path: '/complete', source: 'ANDROID_HOME' });
+    expect(
+      buildToolsVersions('/complete', {
+        isDirectory: (path) => directories.has(path),
+        readDirectory: (path) => entries.get(path) ?? [],
+      }),
+    ).toEqual(['36.0.0']);
+  });
+
+  it('reports build tools as missing when only malformed entries exist', () => {
+    const directories = new Set(['/sdk', '/sdk/platforms/android-36', '/sdk/build-tools']);
+    const result = validateAndroidSdk([{ path: '/sdk', source: 'ANDROID_HOME' }], {
+      isDirectory: (path) => directories.has(path),
+      readDirectory: () => ['README.txt', 'latest', '36'],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.missing).toEqual(['Android SDK Build Tools']);
+  });
+
+  it('detects Java 17 or newer and rejects older or malformed versions', () => {
+    expect(parseJavaMajor('openjdk version "21.0.12" 2026-07-21')).toBe(21);
+    expect(parseJavaMajor('java version "1.8.0_392"')).toBe(8);
+    expect(validateJavaCompatibility(17).ok).toBe(true);
+    expect(validateJavaCompatibility(11).ok).toBe(false);
+    expect(validateJavaCompatibility(null).ok).toBe(false);
+    expect(formatJavaFailure(validateJavaCompatibility(11))).toContain('Java 11 is too old');
+    expect(
+      detectJavaCompatibility({
+        run: () => ({ stdout: '', stderr: 'java: command not found', error: new Error('missing') }),
+      }).ok,
+    ).toBe(false);
+  });
+
   it('reports actionable guidance when the SDK is missing', () => {
     const result = validateAndroidSdk([{ path: '/missing/sdk', source: 'ANDROID_HOME' }], {
       isDirectory: () => false,
@@ -49,5 +121,21 @@ describe('Android SDK preflight', () => {
     expect(result.ok).toBe(false);
     expect(formatFailure(result)).toContain('ANDROID_HOME');
     expect(formatFailure(result)).toContain('android/local.properties');
+  });
+
+  it('propagates the resolved SDK to every Android child process', () => {
+    expect(
+      childEnvironment('/opt/android/sdk', {
+        ANDROID_HOME: '/old/sdk',
+        ANDROID_SDK_ROOT: '/old/sdk',
+        PATH: '/bin',
+      }),
+    ).toMatchObject({
+      ANDROID_HOME: '/opt/android/sdk',
+      ANDROID_SDK_ROOT: '/opt/android/sdk',
+      PATH: '/bin',
+    });
+    expect(gradleTask('debug')).toBe('assembleDebug');
+    expect(gradleTask('release')).toBe('assembleRelease');
   });
 });


### PR DESCRIPTION
## Summary

Android builds now resolve a complete SDK and compatible Java runtime before any child process starts. The selected SDK path is propagated to Capacitor sync and Gradle, and CI uses the same wrapper so local and hosted builds exercise one path.

The preflight now skips incomplete candidates, requires a versioned Build Tools package alongside API 36, reports Java 17+ failures, and includes focused tests for malformed candidates, Java detection, and environment handoff.

## Checks

- `npm run format:check`
- `npm run lint`
- `npm run check`
- `npm test` (75 tests)
- `npm run build`
- `npm run android:doctor`
- `npm run android:debug`
