### PR TITLE
fix: improve library touch targets and progress semantics

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@
 - Virtualize large library grids while preserving stable book ordering and touch scrolling.
 - Load library covers with bounded concurrency, cancel stale refresh work, and clean up browser cover URLs.
 - Make native library metadata refreshes transactional so failed updates leave the saved library unchanged.
+- Increase compact library controls to touch-friendly targets and expose reading progress to assistive technology.
 
 ## 0.3.2
 

--- a/src/lib/components/Library.svelte
+++ b/src/lib/components/Library.svelte
@@ -829,7 +829,7 @@
       </div>
       <div class="card preset-tonal-surface flex shrink-0 gap-1 p-1">
         <button
-          class="btn btn-sm preset-tonal-surface h-8 w-8 !p-0"
+          class="btn btn-sm preset-tonal-surface h-11 w-11 !p-0"
           type="button"
           onclick={() => (settingsVisible = true)}
           aria-label="Open settings"
@@ -843,7 +843,7 @@
           </svg>
         </button>
         <button
-          class="btn btn-sm preset-tonal-surface h-8 w-8 !p-0"
+          class="btn btn-sm preset-tonal-surface h-11 w-11 !p-0"
           type="button"
           onclick={refresh}
           disabled={refreshing}
@@ -896,7 +896,15 @@
             {continueBook.author ?? 'Unknown author'}
           </p>
           <div class="mt-2 flex items-center gap-2">
-            <div class="h-1.5 flex-1 overflow-hidden rounded-full preset-filled-surface-200-800">
+            <div
+              class="h-2 flex-1 overflow-hidden rounded-full preset-filled-surface-200-800"
+              role="progressbar"
+              aria-label={`Reading progress for ${continueBook.title}`}
+              aria-valuemin="0"
+              aria-valuemax="100"
+              aria-valuenow={Math.round(progressOf(continueBook))}
+              aria-valuetext={`${Math.round(progressOf(continueBook))}% complete`}
+            >
               <div
                 class="h-full preset-filled-primary-600-400"
                 style:width={`${progressOf(continueBook)}%`}
@@ -932,7 +940,7 @@
         {#if query}
           <button
             type="button"
-            class="btn btn-sm absolute right-1 top-1/2 h-7 w-7 -translate-y-1/2 p-0 preset-filled-surface-200-800"
+            class="btn btn-sm absolute right-1 top-1/2 h-11 w-11 -translate-y-1/2 p-0 preset-filled-surface-200-800"
             onclick={() => (query = '')}
             aria-label="Clear search"
             title="Clear search"
@@ -1083,7 +1091,15 @@
                       </span>
                     {/if}
                     {#if progressOf(book) > 0}
-                      <div class="absolute inset-x-0 bottom-0 h-1.5">
+                      <div
+                        class="absolute inset-x-0 bottom-0 h-2"
+                        role="progressbar"
+                        aria-label={`Reading progress for ${book.title}`}
+                        aria-valuemin="0"
+                        aria-valuemax="100"
+                        aria-valuenow={Math.round(progressOf(book))}
+                        aria-valuetext={`${Math.round(progressOf(book))}% complete`}
+                      >
                         <div
                           class="h-full preset-filled-primary-600-400"
                           style:width={`${progressOf(book)}%`}
@@ -1101,7 +1117,7 @@
                   </p>
                 </button>
                 <button
-                  class="btn btn-sm preset-tonal-tertiary absolute right-2 bottom-0 z-10 h-7 w-7 !p-0 shadow-md"
+                  class="btn btn-sm preset-tonal-tertiary absolute right-2 bottom-0 z-10 h-11 w-11 !p-0 shadow-md"
                   type="button"
                   onclick={() => openMenu(book)}
                   aria-label={`Book actions for ${book.title}`}

--- a/src/lib/components/Reader.svelte
+++ b/src/lib/components/Reader.svelte
@@ -250,7 +250,15 @@
   </nav>
 
   {#if appearance.progressBar}
-    <div class="reader-progress" aria-hidden="true">
+    <div
+      class="reader-progress"
+      role="progressbar"
+      aria-label="Book reading progress"
+      aria-valuemin="0"
+      aria-valuemax="100"
+      aria-valuenow={Math.round((location?.percentage ?? 0) * 100)}
+      aria-valuetext={`${Math.round((location?.percentage ?? 0) * 100)}% complete`}
+    >
       <div class="reader-progress-track">
         <div
           class="reader-progress-fill"
@@ -345,7 +353,7 @@
           transition:fly={{ y: 12, duration: 150 }}
         >
           <button
-            class="btn btn-sm preset-tonal-surface absolute right-3 top-3 h-8 w-8 p-0"
+            class="btn btn-sm preset-tonal-surface absolute right-3 top-3 h-11 w-11 p-0"
             type="button"
             onclick={() => (settingsVisible = false)}
             aria-label="Close reading appearance"
@@ -365,6 +373,7 @@
                 class:active-mode={appearance.mode === mode}
                 class="btn preset-outlined-surface-300-700 capitalize"
                 type="button"
+                aria-pressed={appearance.mode === mode}
                 onclick={() => updateAppearance({ mode: mode as ReadingMode })}>{mode}</button
               >
             {/each}
@@ -485,7 +494,7 @@
           transition:fly={{ y: 12, duration: 150 }}
         >
           <button
-            class="btn btn-sm preset-tonal-surface absolute right-3 top-3 h-8 w-8 p-0"
+            class="btn btn-sm preset-tonal-surface absolute right-3 top-3 h-11 w-11 p-0"
             type="button"
             onclick={() => (tocVisible = false)}
             aria-label="Close table of contents"


### PR DESCRIPTION
## Summary
- raise compact library controls to 44px touch targets
- expose Continue Reading and card progress as accessible progress bars
- keep progress text synchronized with the visual indicator

## Validation
- `npm run check`
- `npm test -- --run`
