### PR TITLE
Add modal focus management

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add accessible modal semantics, focus trapping, Escape/backdrop closing, and focus restoration to library and reader panels.
 - Add an Android SDK preflight that explains missing local SDK configuration before Gradle builds.
 - Virtualize large library grids while preserving stable book ordering and touch scrolling.
 - Load library covers with bounded concurrency, cancel stale refresh work, and clean up browser cover URLs.

--- a/src/lib/a11y/modal-focus.test.ts
+++ b/src/lib/a11y/modal-focus.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, expect, it, vi } from 'vitest';
+import { focusFirstElement, restoreFocus, trapModalKeydown } from './modal-focus';
+
+let dialog: HTMLDivElement;
+let first: HTMLButtonElement;
+let last: HTMLButtonElement;
+
+beforeEach(() => {
+  dialog = document.createElement('div');
+  dialog.tabIndex = -1;
+  first = document.createElement('button');
+  last = document.createElement('button');
+  dialog.append(first, last);
+  document.body.append(dialog);
+});
+
+it('focuses the first available control when a modal opens', () => {
+  focusFirstElement(dialog);
+  expect(document.activeElement).toBe(first);
+});
+
+it('wraps forward and backward tab navigation inside the modal', () => {
+  last.focus();
+  const forward = new KeyboardEvent('keydown', {
+    key: 'Tab',
+    bubbles: true,
+    cancelable: true,
+  });
+  trapModalKeydown(forward, dialog, vi.fn());
+  expect(document.activeElement).toBe(first);
+  expect(forward.defaultPrevented).toBe(true);
+
+  first.focus();
+  const backward = new KeyboardEvent('keydown', {
+    key: 'Tab',
+    shiftKey: true,
+    bubbles: true,
+    cancelable: true,
+  });
+  trapModalKeydown(backward, dialog, vi.fn());
+  expect(document.activeElement).toBe(last);
+  expect(backward.defaultPrevented).toBe(true);
+});
+
+it('closes on Escape and restores focus to a connected opener', () => {
+  const opener = document.createElement('button');
+  document.body.append(opener);
+  const close = vi.fn();
+  const event = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true });
+
+  trapModalKeydown(event, dialog, close);
+  restoreFocus(opener);
+
+  expect(close).toHaveBeenCalledOnce();
+  expect(event.defaultPrevented).toBe(true);
+  expect(document.activeElement).toBe(opener);
+});

--- a/src/lib/a11y/modal-focus.ts
+++ b/src/lib/a11y/modal-focus.ts
@@ -1,0 +1,58 @@
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'area[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  'iframe',
+  '[contenteditable="true"]',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+export function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+    (element) => element.getAttribute('aria-hidden') !== 'true' && !element.hidden,
+  );
+}
+
+export function focusFirstElement(container: HTMLElement | null): void {
+  if (!container) return;
+  const first = getFocusableElements(container)[0];
+  (first ?? container).focus();
+}
+
+export function restoreFocus(element: HTMLElement | null): void {
+  if (element?.isConnected && !element.hasAttribute('disabled')) element.focus();
+}
+
+export function trapModalKeydown(
+  event: KeyboardEvent,
+  container: HTMLElement,
+  close: () => void,
+): void {
+  if (event.key === 'Escape') {
+    event.preventDefault();
+    close();
+    return;
+  }
+  if (event.key !== 'Tab') return;
+
+  const focusable = getFocusableElements(container);
+  if (focusable.length === 0) {
+    event.preventDefault();
+    container.focus();
+    return;
+  }
+
+  const first = focusable[0]!;
+  const last = focusable[focusable.length - 1]!;
+  const active = document.activeElement;
+  if (event.shiftKey && (active === first || !container.contains(active))) {
+    event.preventDefault();
+    last.focus();
+  } else if (!event.shiftKey && (active === last || !container.contains(active))) {
+    event.preventDefault();
+    first.focus();
+  }
+}

--- a/src/lib/components/Library.svelte
+++ b/src/lib/components/Library.svelte
@@ -2,7 +2,7 @@
   import { App } from '@capacitor/app';
   import { Capacitor } from '@capacitor/core';
   import { Network } from '@capacitor/network';
-  import { onDestroy, onMount } from 'svelte';
+  import { tick, onDestroy, onMount } from 'svelte';
   import { fade, fly } from 'svelte/transition';
   import {
     getBooks,
@@ -37,6 +37,7 @@
   import Reader from './Reader.svelte';
   import TurnleafLogo from './TurnleafLogo.svelte';
   import { calculateVirtualWindow, type VirtualWindow } from './library-virtualization';
+  import { focusFirstElement, restoreFocus, trapModalKeydown } from '../a11y/modal-focus';
 
   const skeletonThemes = [
     'catppuccin',
@@ -255,6 +256,12 @@
   let deletingServer = $state(false);
   let confirmDeleteServer = $state(false);
   let actionMenuBook = $state<BookRecord | null>(null);
+  let actionMenuDialog = $state<HTMLElement | null>(null);
+  let conflictDialog = $state<HTMLElement | null>(null);
+  let settingsDialog = $state<HTMLElement | null>(null);
+  let actionMenuOpener: HTMLElement | null = null;
+  let conflictOpener: HTMLElement | null = null;
+  let settingsOpener: HTMLElement | null = null;
   let libraryMain = $state<HTMLElement | null>(null);
   let virtualGrid = $state<HTMLElement | null>(null);
   let gridColumns = $state(2);
@@ -277,6 +284,16 @@
 
   function progressOf(book: BookRecord): number {
     return book.pages ? Math.min(100, (book.pagesRead / book.pages) * 100) : 0;
+  }
+
+  function activeElement(): HTMLElement | null {
+    return typeof document !== 'undefined' && document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+  }
+
+  function focusModal(getDialog: () => HTMLElement | null): void {
+    void tick().then(() => focusFirstElement(getDialog()));
   }
 
   function insecureServer(): boolean {
@@ -404,9 +421,9 @@
       await registerListener(
         await App.addListener('backButton', () => {
           if (destroyed) return;
-          if (actionMenuBook) actionMenuBook = null;
+          if (actionMenuBook) closeMenu();
           else if (reading) reading = null;
-          else if (settingsVisible) settingsVisible = false;
+          else if (settingsVisible) closeSettings();
           else void App.exitApp();
         }),
       ),
@@ -627,7 +644,7 @@
       return;
     }
     if (openProgress === 'conflict' && local && remote) {
-      conflict = { book, url: file.webViewUrl, localCfi: local.cfi, remote };
+      openConflict({ book, url: file.webViewUrl, localCfi: local.cfi, remote });
       return;
     }
     reading = {
@@ -693,26 +710,57 @@
     );
     void flushProgress(client).catch(() => {});
     message = `${book.title} marked as read.`;
-    actionMenuBook = null;
+    closeMenu();
   }
 
   async function syncFurthest(book: BookRecord): Promise<void> {
-    actionMenuBook = null;
+    closeMenu();
     await open(book, { preferFurthest: true });
   }
 
   function openMenu(book: BookRecord): void {
+    actionMenuOpener = activeElement();
     actionMenuBook = book;
+    focusModal(() => actionMenuDialog);
   }
 
   function closeMenu(): void {
     actionMenuBook = null;
+    const opener = actionMenuOpener;
+    actionMenuOpener = null;
+    restoreFocus(opener);
+  }
+
+  function openConflict(next: NonNullable<typeof conflict>): void {
+    conflictOpener = activeElement();
+    conflict = next;
+    focusModal(() => conflictDialog);
+  }
+
+  function closeConflict(): void {
+    conflict = null;
+    const opener = conflictOpener;
+    conflictOpener = null;
+    restoreFocus(opener);
+  }
+
+  function openSettings(): void {
+    settingsOpener = activeElement();
+    settingsVisible = true;
+    focusModal(() => settingsDialog);
+  }
+
+  function closeSettings(): void {
+    settingsVisible = false;
+    const opener = settingsOpener;
+    settingsOpener = null;
+    restoreFocus(opener);
   }
 
   async function removeAllDownloads(): Promise<void> {
     for (const book of books.filter((item) => item.downloadPath)) await remove(book);
     message = 'Downloaded books removed. Kavita was not changed.';
-    settingsVisible = false;
+    closeSettings();
   }
 
   async function clearCache(): Promise<void> {
@@ -722,7 +770,7 @@
     clearCovers();
     void loadCovers(books);
     message = 'Cover cache cleared.';
-    settingsVisible = false;
+    closeSettings();
   }
 
   async function updateTheme(next: SkeletonTheme): Promise<void> {
@@ -772,7 +820,7 @@
       onApiKeyChange(nextKey);
       replacementApiKey = '';
       message = 'API key updated.';
-      settingsVisible = false;
+      closeSettings();
     } catch (cause) {
       settingsError =
         cause instanceof Error ? cause.message : 'Turnleaf could not update the API key.';
@@ -793,7 +841,7 @@
       await removeServer(server.id);
       onServerDeleted();
       message = 'Server removed. Add it again to browse the library.';
-      settingsVisible = false;
+      closeSettings();
     } catch (cause) {
       settingsError =
         cause instanceof Error ? cause.message : 'Turnleaf could not remove the server.';
@@ -819,6 +867,7 @@
   <main
     bind:this={libraryMain}
     class="mx-auto min-h-full max-w-6xl px-4 pb-16 pt-[max(1.5rem,env(safe-area-inset-top))] sm:px-6"
+    inert={Boolean(actionMenuBook || conflict || settingsVisible)}
   >
     <header class="flex items-center justify-between gap-4">
       <div class="flex min-w-0 items-center gap-3">
@@ -831,7 +880,7 @@
         <button
           class="btn btn-sm preset-tonal-surface h-8 w-8 !p-0"
           type="button"
-          onclick={() => (settingsVisible = true)}
+          onclick={openSettings}
           aria-label="Open settings"
           title="Settings"
         >
@@ -1130,14 +1179,20 @@
     transition:fade
     onclick={(event) => event.target === event.currentTarget && closeMenu()}
   >
-    <section
+    <div
+      bind:this={actionMenuDialog}
       class="card preset-filled-surface-50-950 w-full max-w-md overflow-hidden p-4 shadow-2xl"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="book-actions-title"
+      tabindex="-1"
+      onkeydown={(event) => trapModalKeydown(event, actionMenuDialog!, closeMenu)}
       transition:fly={{ y: 16, duration: 150 }}
     >
       <div class="flex items-start justify-between gap-4">
         <div class="min-w-0">
           <p class="text-xs uppercase tracking-wider text-surface-700-300">Book actions</p>
-          <h2 class="mt-1 truncate font-serif text-2xl text-surface-950-50">
+          <h2 id="book-actions-title" class="mt-1 truncate font-serif text-2xl text-surface-950-50">
             {actionMenuBook.title}
           </h2>
           <p class="truncate text-sm text-surface-700-300">
@@ -1226,7 +1281,7 @@
           </button>
         {/if}
       </div>
-    </section>
+    </div>
   </div>
 {/if}
 
@@ -1235,12 +1290,19 @@
     class="fixed inset-0 z-40 grid place-items-center bg-black/55 p-5"
     role="presentation"
     transition:fade
+    onclick={(event) => event.target === event.currentTarget && closeConflict()}
   >
     <div
+      bind:this={conflictDialog}
       class="card preset-filled-surface-50-950 w-full max-w-sm p-6"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="sync-conflict-title"
+      tabindex="-1"
+      onkeydown={(event) => trapModalKeydown(event, conflictDialog!, closeConflict)}
       transition:fly={{ y: 16, duration: 150 }}
     >
-      <h2 class="font-serif text-2xl">Choose where to continue</h2>
+      <h2 id="sync-conflict-title" class="font-serif text-2xl">Choose where to continue</h2>
       <p class="mt-3 text-surface-600-400">
         This device and Kavita both moved since the last sync.
       </p>
@@ -1256,7 +1318,7 @@
               xpath: null,
               percentage: null,
             };
-            conflict = null;
+            closeConflict();
           }}>Continue from this device</button
         >
         <button
@@ -1270,7 +1332,7 @@
               xpath: conflict!.remote.bookScrollId ?? null,
               percentage: remotePercentage(conflict!.remote, conflict!.book),
             };
-            conflict = null;
+            closeConflict();
           }}>Continue from Kavita</button
         >
       </div>
@@ -1283,17 +1345,22 @@
     class="fixed inset-0 z-50 grid place-items-center bg-black/55 p-4"
     role="presentation"
     transition:fade
-    onclick={(event) => event.target === event.currentTarget && (settingsVisible = false)}
+    onclick={(event) => event.target === event.currentTarget && closeSettings()}
   >
-    <section
+    <div
+      bind:this={settingsDialog}
       class="card preset-filled-surface-50-950 relative w-full max-w-md max-h-[88dvh] overflow-auto p-6"
-      aria-label="Settings"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="library-settings-title"
+      tabindex="-1"
+      onkeydown={(event) => trapModalKeydown(event, settingsDialog!, closeSettings)}
       transition:fly={{ y: 16, duration: 150 }}
     >
       <button
         class="btn btn-sm preset-tonal-surface absolute right-4 top-4 h-9 w-9 p-0"
         type="button"
-        onclick={() => (settingsVisible = false)}
+        onclick={closeSettings}
         aria-label="Close settings"
       >
         <svg aria-hidden="true" viewBox="0 0 24 24" class="h-5 w-5">
@@ -1304,7 +1371,7 @@
         </svg>
       </button>
 
-      <h2 class="font-serif text-3xl">Settings</h2>
+      <h2 id="library-settings-title" class="font-serif text-3xl">Settings</h2>
 
       <div class="mt-6">
         <div class="mt-3 grid grid-cols-2 gap-2">
@@ -1490,7 +1557,7 @@
           </div>
         </div>
       {/if}
-    </section>
+    </div>
   </div>
 {/if}
 

--- a/src/lib/components/Reader.svelte
+++ b/src/lib/components/Reader.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { App } from '@capacitor/app';
   import { Capacitor, type PluginListenerHandle } from '@capacitor/core';
-  import { onDestroy, onMount } from 'svelte';
+  import { tick, onDestroy, onMount } from 'svelte';
   import { fade, fly } from 'svelte/transition';
   import { Animation, StatusBar } from '@capacitor/status-bar';
   import { getPreference, setPreference } from '../database/database';
@@ -17,6 +17,7 @@
     type ReadingMode,
   } from '../reader/appearance';
   import { ReaderSession, type ReaderLocation, type TocItem } from '../reader/session';
+  import { focusFirstElement, restoreFocus, trapModalKeydown } from '../a11y/modal-focus';
 
   let {
     bookUrl,
@@ -43,6 +44,10 @@
   let controlsVisible = $state(false);
   let settingsVisible = $state(false);
   let tocVisible = $state(false);
+  let settingsPanel = $state<HTMLElement | null>(null);
+  let tocPanel = $state<HTMLElement | null>(null);
+  let settingsOpener: HTMLElement | null = null;
+  let tocOpener: HTMLElement | null = null;
   let toc = $state<TocItem[]>([]);
   let appearance = $state<Appearance>({ ...defaultAppearance });
   let location = $state<ReaderLocation | null>(null);
@@ -135,6 +140,46 @@
     scheduleChromeHide();
   }
 
+  function activeElement(): HTMLElement | null {
+    return typeof document !== 'undefined' && document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+  }
+
+  function focusPanel(getPanel: () => HTMLElement | null): void {
+    void tick().then(() => focusFirstElement(getPanel()));
+  }
+
+  function openSettings(): void {
+    settingsOpener = activeElement();
+    settingsVisible = true;
+    tocVisible = false;
+    tocOpener = null;
+    focusPanel(() => settingsPanel);
+  }
+
+  function closeSettings(): void {
+    settingsVisible = false;
+    const opener = settingsOpener;
+    settingsOpener = null;
+    restoreFocus(opener);
+  }
+
+  function openToc(): void {
+    tocOpener = activeElement();
+    tocVisible = true;
+    settingsVisible = false;
+    settingsOpener = null;
+    focusPanel(() => tocPanel);
+  }
+
+  function closeToc(): void {
+    tocVisible = false;
+    const opener = tocOpener;
+    tocOpener = null;
+    restoreFocus(opener);
+  }
+
   function showFooter(): void {
     footerVisible = true;
     scheduleChromeHide();
@@ -144,8 +189,8 @@
     if (hideTimer !== null) window.clearTimeout(hideTimer);
     hideTimer = window.setTimeout(() => {
       controlsVisible = false;
-      settingsVisible = false;
-      tocVisible = false;
+      closeSettings();
+      closeToc();
       footerVisible = false;
     }, 5_000);
   }
@@ -239,7 +284,11 @@
 <div class="reader-shell" data-mode={appearance.mode}>
   <div class="reader-viewport" bind:this={viewport}></div>
 
-  <nav class="tap-zones" aria-label="Page navigation">
+  <nav
+    class="tap-zones"
+    aria-label="Page navigation"
+    inert={Boolean(settingsVisible || tocVisible)}
+  >
     <button type="button" aria-label="Previous page" onclick={() => turn('previous')}></button>
     <button
       type="button"
@@ -281,7 +330,11 @@
 
   {#if controlsVisible}
     <div class="reader-overlay" data-controls transition:fade={{ duration: 120 }}>
-      <header class="reader-bar reader-top" transition:fly={{ y: -8, duration: 140 }}>
+      <header
+        class="reader-bar reader-top"
+        inert={Boolean(settingsVisible || tocVisible)}
+        transition:fly={{ y: -8, duration: 140 }}
+      >
         <div class="grid w-full grid-cols-4 gap-2">
           <button
             class="btn preset-tonal-surface min-h-12"
@@ -294,22 +347,18 @@
           <button
             class="btn preset-tonal-surface min-h-12"
             type="button"
-            onclick={() => {
-              tocVisible = !tocVisible;
-              settingsVisible = false;
-            }}
+            onclick={() => (tocVisible ? closeToc() : openToc())}
             aria-expanded={tocVisible}
+            aria-controls="reader-contents"
           >
             Contents
           </button>
           <button
             class="btn preset-tonal-surface min-h-12"
             type="button"
-            onclick={() => {
-              settingsVisible = !settingsVisible;
-              tocVisible = false;
-            }}
+            onclick={() => (settingsVisible ? closeSettings() : openSettings())}
             aria-expanded={settingsVisible}
+            aria-controls="reader-appearance"
           >
             Text
           </button>
@@ -339,15 +388,32 @@
         </p>
       </header>
 
+      {#if settingsVisible || tocVisible}
+        <button
+          class="reader-panel-backdrop"
+          type="button"
+          tabindex="-1"
+          aria-label="Close reader panel"
+          onclick={() => (settingsVisible ? closeSettings() : closeToc())}
+        ></button>
+      {/if}
+
       {#if settingsVisible}
-        <section
+        <div
+          bind:this={settingsPanel}
           class="reader-settings card preset-filled-surface-50-950 relative"
+          id="reader-appearance"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="reader-appearance-title"
+          tabindex="-1"
+          onkeydown={(event) => trapModalKeydown(event, settingsPanel!, closeSettings)}
           transition:fly={{ y: 12, duration: 150 }}
         >
           <button
             class="btn btn-sm preset-tonal-surface absolute right-3 top-3 h-8 w-8 p-0"
             type="button"
-            onclick={() => (settingsVisible = false)}
+            onclick={closeSettings}
             aria-label="Close reading appearance"
             title="Close"
           >
@@ -358,7 +424,7 @@
               />
             </svg>
           </button>
-          <h2 class="font-serif text-xl">Reading appearance</h2>
+          <h2 id="reader-appearance-title" class="font-serif text-xl">Reading appearance</h2>
           <div class="mt-4 grid grid-cols-2 gap-2" aria-label="Reading color mode">
             {#each ['light', 'dark'] as mode (mode)}
               <button
@@ -475,19 +541,25 @@
             />
             Keep screen on while reading
           </label>
-        </section>
+        </div>
       {/if}
 
       {#if tocVisible}
-        <nav
+        <div
+          bind:this={tocPanel}
           class="reader-settings card preset-filled-surface-50-950 relative"
-          aria-label="Table of contents"
+          id="reader-contents"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="reader-contents-title"
+          tabindex="-1"
+          onkeydown={(event) => trapModalKeydown(event, tocPanel!, closeToc)}
           transition:fly={{ y: 12, duration: 150 }}
         >
           <button
             class="btn btn-sm preset-tonal-surface absolute right-3 top-3 h-8 w-8 p-0"
             type="button"
-            onclick={() => (tocVisible = false)}
+            onclick={closeToc}
             aria-label="Close table of contents"
             title="Close"
           >
@@ -498,7 +570,7 @@
               />
             </svg>
           </button>
-          <h2 class="font-serif text-xl">Contents</h2>
+          <h2 id="reader-contents-title" class="font-serif text-xl">Contents</h2>
           <div class="mt-3 max-h-[55dvh] overflow-auto">
             {#each toc as item (item.href)}
               <button
@@ -506,12 +578,12 @@
                 type="button"
                 onclick={() => {
                   void session?.display(item.href);
-                  tocVisible = false;
+                  closeToc();
                 }}>{item.label}</button
               >
             {/each}
           </div>
-        </nav>
+        </div>
       {/if}
     </div>
   {/if}
@@ -703,6 +775,16 @@
     margin-inline: auto;
     max-width: 30rem;
     padding: 1.25rem;
+    z-index: 1;
+  }
+
+  .reader-panel-backdrop {
+    position: absolute;
+    z-index: 0;
+    inset: 0;
+    border: 0;
+    background: hsl(0 0% 0% / 0.24);
+    pointer-events: auto;
   }
 
   .active-mode {


### PR DESCRIPTION
## Summary
- add shared focus-first, focus-restore, and keyboard trap helpers for modal panels
- apply dialog semantics and focus management to library book actions, sync conflicts, and settings
- apply dialog semantics, focus management, backdrop closing, and inert background controls to reader appearance and contents panels
- add focused keyboard behavior tests and update release notes

## Validation
- `npm run check`
- `npm run lint -- --max-warnings=0`
- `npm run format:check`
- `npm test -- --run`
