### PR TITLE
Isolate rendered EPUB content from remote resources

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Isolate rendered EPUB content from remote resources and unsafe navigation while preserving internal links and local assets.
 - Add an Android SDK preflight that explains missing local SDK configuration before Gradle builds.
 - Virtualize large library grids while preserving stable book ordering and touch scrolling.
 - Load library covers with bounded concurrency, cancel stale refresh work, and clean up browser cover URLs.

--- a/src/lib/reader/fixtures/hostile-epub.test.ts
+++ b/src/lib/reader/fixtures/hostile-epub.test.ts
@@ -1,0 +1,69 @@
+import { expect, it, vi } from 'vitest';
+import fixture from './hostile-epub.xhtml?raw';
+import { sanitizeEpubDocument } from '../session';
+
+it('keeps local EPUB content while removing network and executable references', async () => {
+  const document = new DOMParser().parseFromString(fixture, 'application/xhtml+xml');
+
+  await sanitizeEpubDocument(document);
+
+  expect(document.querySelector('base')).toBeNull();
+  expect(document.querySelector('script, iframe, form, meta[http-equiv="refresh"]')).toBeNull();
+  expect(
+    document.querySelector('meta[http-equiv="Content-Security-Policy"]')?.getAttribute('content'),
+  ).toContain("connect-src 'none'");
+  expect(document.body?.getAttribute('onload')).toBeNull();
+  expect(document.querySelector('#internal')?.getAttribute('href')).toBe('chapter-2.xhtml#section');
+  expect(document.querySelector('#fragment')?.getAttribute('href')).toBe('#section');
+  expect(document.querySelector('#remote')?.getAttribute('href')).toBeNull();
+  expect(document.querySelector('#encoded')?.getAttribute('href')).toBeNull();
+  expect(document.querySelector('#scheme-relative')?.getAttribute('href')).toBeNull();
+  expect(document.querySelector('#file')?.getAttribute('href')).toBeNull();
+  expect(document.querySelector('#malformed')?.getAttribute('href')).toBeNull();
+  expect(document.querySelector('#local-image')?.getAttribute('src')).toBe('../Images/cover.jpg');
+  expect(document.querySelector('#embedded-image')?.getAttribute('src')).toMatch(
+    /^data:image\/png/,
+  );
+  expect(document.querySelector('#remote-image')?.getAttribute('src')).toBeNull();
+  expect(document.querySelector('#remote-srcset')?.getAttribute('srcset')).toBe(
+    '../Images/a.jpg 2x',
+  );
+  expect(document.querySelector('#remote-svg-image')?.getAttribute('href')).toBeNull();
+  expect(document.querySelector('#remote-video')?.getAttribute('poster')).toBeNull();
+  expect(document.querySelector('link[href="styles/book.css"]')).toBeNull();
+  expect(document.querySelector('link[href^="https:"]')).toBeNull();
+  expect(document.querySelector('style')?.textContent).toContain('../Images/paper.png');
+  expect(document.querySelector('style')?.textContent).not.toContain('attacker.example');
+});
+
+it('sanitizes a local stylesheet before restoring its safe rules', async () => {
+  const document = new DOMParser().parseFromString(
+    '<html><head><base href="http://localhost/_capacitor_file/books/book.epub/OEBPS/" /><link rel="stylesheet" href="styles/book.css" /></head><body /></html>',
+    'application/xhtml+xml',
+  );
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(
+      async () =>
+        new Response(
+          '.cover { background: url(../Images/cover.jpg); } .remote { background: url(https://attacker.example/pixel); }',
+          {
+            status: 200,
+            headers: { 'content-type': 'text/css' },
+          },
+        ),
+    ),
+  );
+
+  await sanitizeEpubDocument(document);
+
+  expect(document.querySelector('base')?.getAttribute('href')).toContain('localhost');
+  expect(document.querySelector('link[rel="stylesheet"]')).toBeNull();
+  expect(document.querySelector('style')?.textContent).toContain('../Images/cover.jpg');
+  expect(document.querySelector('style')?.textContent).not.toContain('attacker.example');
+  const requested = vi.mocked(fetch).mock.calls[0]?.[0];
+  expect(requested instanceof URL ? requested.href : requested).toBe(
+    'http://localhost/_capacitor_file/books/book.epub/OEBPS/styles/book.css',
+  );
+  vi.unstubAllGlobals();
+});

--- a/src/lib/reader/fixtures/hostile-epub.xhtml
+++ b/src/lib/reader/fixtures/hostile-epub.xhtml
@@ -1,0 +1,37 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <base href="https://attacker.example/" />
+    <link rel="stylesheet" href="https://attacker.example/remote.css" />
+    <link rel="stylesheet" href="styles/book.css" />
+    <meta http-equiv="refresh" content="0;url=https://attacker.example/redirect" />
+    <style>
+      @import url('https://attacker.example/remote.css');
+      body {
+        background-image: url('../Images/paper.png');
+      }
+      .remote {
+        background-image: url(//attacker.example/pixel);
+      }
+    </style>
+  </head>
+  <body onload="fetch('https://attacker.example/beacon')">
+    <script>
+      fetch('https://attacker.example/script');
+    </script>
+    <iframe src="https://attacker.example/frame" />
+    <form action="https://attacker.example/submit" />
+    <a id="internal" href="chapter-2.xhtml#section">Continue</a>
+    <a id="fragment" href="#section">Section</a>
+    <a id="remote" href="HTTPS://attacker.example/leave">Remote</a>
+    <a id="encoded" href="java%73cript:alert(1)">Encoded</a>
+    <a id="scheme-relative" href="//attacker.example/leave">Scheme relative</a>
+    <a id="file" href="file:///etc/passwd">File</a>
+    <a id="malformed" href="%E0%A4%A">Malformed</a>
+    <img id="local-image" src="../Images/cover.jpg" />
+    <img id="embedded-image" src="data:image/png;base64,iVBORw0KGgo=" />
+    <img id="remote-image" src="https://attacker.example/pixel" />
+    <img id="remote-srcset" srcset="https://attacker.example/a.jpg 1x, ../Images/a.jpg 2x" />
+    <svg><image id="remote-svg-image" href="https://attacker.example/image" /></svg>
+    <video id="remote-video" poster="https://attacker.example/poster" />
+  </body>
+</html>

--- a/src/lib/reader/session.ts
+++ b/src/lib/reader/session.ts
@@ -108,6 +108,225 @@ const MODE_COLORS = {
   },
 } as const;
 
+type EpubReferenceKind = 'link' | 'resource' | 'stylesheet';
+
+const RESOURCE_ATTRIBUTES = new Set([
+  'action',
+  'background',
+  'cite',
+  'data',
+  'formaction',
+  'href',
+  'longdesc',
+  'manifest',
+  'poster',
+  'src',
+  'xlink:href',
+]);
+
+const SAFE_DATA_IMAGE = /^data:image\/(?:gif|jpe?g|png|webp|avif);base64,[a-z0-9+/=\s]+$/i;
+const SAFE_DATA_STYLESHEET = /^data:text\/css(?:;charset=[^;,]+)?(?:;base64)?,/i;
+
+function hasUnsafeControl(value: string): boolean {
+  return [...value].some((character) => {
+    const code = character.charCodeAt(0);
+    return code <= 0x1f || code === 0x7f;
+  });
+}
+
+function decodedReference(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed || hasUnsafeControl(trimmed)) return null;
+  try {
+    const decoded = decodeURIComponent(trimmed).trim();
+    return hasUnsafeControl(decoded) ? null : decoded;
+  } catch {
+    return null;
+  }
+}
+
+function isSafeEpubReference(value: string, kind: EpubReferenceKind): boolean {
+  const decoded = decodedReference(value);
+  if (!decoded) return false;
+  if (decoded.startsWith('#')) return true;
+  if (kind === 'resource' && SAFE_DATA_IMAGE.test(decoded)) return true;
+  if (kind === 'stylesheet' && SAFE_DATA_STYLESHEET.test(decoded)) return true;
+  if (kind !== 'link' && decoded.toLowerCase().startsWith('blob:')) return true;
+  if (/^[a-z][a-z\d+.-]*:/i.test(decoded)) return false;
+  if (decoded.startsWith('/') || decoded.startsWith('\\') || decoded.startsWith('//')) return false;
+  return true;
+}
+
+function sanitizeSrcset(value: string): string | null {
+  const candidates = value
+    .split(',')
+    .map((candidate) => candidate.trim())
+    .filter(Boolean)
+    .map((candidate) => {
+      const match = candidate.match(/^(\S+)(?:\s+(.+))?$/);
+      if (!match?.[1] || !isSafeEpubReference(match[1], 'resource')) return null;
+      return match[2] ? `${match[1]} ${match[2]}` : match[1];
+    })
+    .filter((candidate): candidate is string => candidate !== null);
+  return candidates.length ? candidates.join(', ') : null;
+}
+
+function sanitizeCss(value: string): string {
+  const withoutRemoteImports = value.replace(
+    /@import\s+(?:url\(\s*)?(?:'[^']*'|"[^"]*"|[^;\s)]+)\s*\)?\s*;?/gi,
+    (statement) => {
+      const match = statement.match(/(?:url\(\s*)?(['"]?)([^'"\s)]+)\1\s*\)?/i);
+      return match?.[2] && isSafeEpubReference(match[2], 'resource') ? statement : '';
+    },
+  );
+  return withoutRemoteImports.replace(
+    /url\(\s*(['"]?)(.*?)\1\s*\)/gi,
+    (whole, _quote: string, url: string) => (isSafeEpubReference(url, 'resource') ? whole : 'none'),
+  );
+}
+
+function isLocalContentUrl(value: string, document: Document): boolean {
+  try {
+    const url = new URL(value, document.baseURI);
+    if (['blob:', 'file:', 'capacitor:', 'ionic:'].includes(url.protocol)) return true;
+    if (!['http:', 'https:'].includes(url.protocol)) return false;
+    return ['localhost', '127.0.0.1', '[::1]'].includes(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+function decodeDataStylesheet(value: string): string | null {
+  if (!SAFE_DATA_STYLESHEET.test(value)) return null;
+  const separator = value.indexOf(',');
+  if (separator < 0) return null;
+  const metadata = value.slice(0, separator).toLowerCase();
+  const body = value.slice(separator + 1);
+  try {
+    if (metadata.endsWith(';base64')) return atob(body);
+    return decodeURIComponent(body);
+  } catch {
+    return null;
+  }
+}
+
+async function sanitizeStylesheets(document: Document): Promise<void> {
+  const links = [...document.querySelectorAll<HTMLLinkElement>('link[href]')].filter((link) =>
+    (link.getAttribute('rel') ?? '').toLowerCase().split(/\s+/).includes('stylesheet'),
+  );
+  await Promise.all(
+    links.map(async (link) => {
+      const href = link.getAttribute('href') ?? '';
+      const next = link.nextSibling;
+      const parent = link.parentNode;
+      link.remove();
+      let stylesheet: string | null = decodeDataStylesheet(href);
+      if (!stylesheet && isLocalContentUrl(href, document)) {
+        try {
+          const response = await fetch(new URL(href, document.baseURI));
+          if (response.ok) stylesheet = await response.text();
+        } catch {
+          stylesheet = null;
+        }
+      }
+      if (!stylesheet) return;
+      const style = document.createElement('style');
+      style.textContent = sanitizeCss(stylesheet);
+      parent?.insertBefore(style, next);
+    }),
+  );
+}
+
+function installEpubContentPolicy(document: Document): void {
+  const head =
+    document.head ??
+    document.documentElement.insertBefore(
+      document.createElement('head'),
+      document.documentElement.firstChild,
+    );
+  const policy = document.createElement('meta');
+  policy.setAttribute('http-equiv', 'Content-Security-Policy');
+  policy.setAttribute(
+    'content',
+    [
+      "default-src 'none'",
+      "base-uri 'self'",
+      "connect-src 'none'",
+      "font-src 'self' data: blob:",
+      "frame-src 'none'",
+      "img-src 'self' data: blob:",
+      "manifest-src 'none'",
+      "media-src 'self' data: blob:",
+      "object-src 'none'",
+      "script-src 'none'",
+      "style-src 'self' 'unsafe-inline' data: blob:",
+      "worker-src 'none'",
+    ].join('; '),
+  );
+  head.prepend(policy);
+}
+
+function isSafeBaseReference(value: string, document: Document): boolean {
+  const decoded = decodedReference(value);
+  if (!decoded) return false;
+  if (!/^[a-z][a-z\d+.-]*:/i.test(decoded)) {
+    return !decoded.startsWith('/') && !decoded.startsWith('\\') && !decoded.startsWith('//');
+  }
+  return isLocalContentUrl(decoded, document);
+}
+
+export async function sanitizeEpubDocument(document: Document): Promise<void> {
+  document.querySelectorAll('base').forEach((base) => {
+    const href = base.getAttribute('href') ?? '';
+    if (!isSafeBaseReference(href, document)) base.remove();
+  });
+  document
+    .querySelectorAll('script, iframe, object, embed, form, meta[http-equiv]')
+    .forEach((node) => node.remove());
+
+  document.querySelectorAll<HTMLElement>('*').forEach((element) => {
+    for (const attribute of [...element.attributes]) {
+      const name = attribute.name.toLowerCase();
+      if (name.startsWith('on') || name === 'ping') {
+        element.removeAttribute(attribute.name);
+        continue;
+      }
+      if (name === 'srcset' || name === 'imagesrcset') {
+        const safeSrcset = sanitizeSrcset(attribute.value);
+        if (safeSrcset) element.setAttribute(attribute.name, safeSrcset);
+        else element.removeAttribute(attribute.name);
+        continue;
+      }
+      if (name === 'style') {
+        const safeStyle = sanitizeCss(attribute.value);
+        if (safeStyle) element.setAttribute(attribute.name, safeStyle);
+        else element.removeAttribute(attribute.name);
+        continue;
+      }
+      if (element.localName === 'base' && name === 'href') continue;
+      if (!RESOURCE_ATTRIBUTES.has(name)) continue;
+      const isStylesheet =
+        name === 'href' &&
+        element.localName === 'link' &&
+        (element.getAttribute('rel') ?? '').toLowerCase().split(/\s+/).includes('stylesheet');
+      const kind =
+        name === 'href' && ['a', 'area'].includes(element.localName)
+          ? 'link'
+          : isStylesheet
+            ? 'stylesheet'
+            : 'resource';
+      if (!isSafeEpubReference(attribute.value, kind)) element.removeAttribute(attribute.name);
+    }
+  });
+
+  document.querySelectorAll('style').forEach((style) => {
+    const safeStyle = sanitizeCss(style.textContent ?? '');
+    style.textContent = safeStyle;
+  });
+  await sanitizeStylesheets(document);
+  installEpubContentPolicy(document);
+}
+
 export class ReaderSession {
   private readonly book;
   private rendition: Rendition | null = null;
@@ -281,14 +500,8 @@ export class ReaderSession {
     this.book.destroy();
   }
 
-  private harden(contents: Contents): void {
-    contents.document
-      .querySelectorAll('script, iframe, object, embed, form')
-      .forEach((node) => node.remove());
-    contents.document.querySelectorAll<HTMLAnchorElement>('a[href]').forEach((anchor) => {
-      const href = anchor.getAttribute('href') ?? '';
-      if (/^(https?:|javascript:|data:)/i.test(href)) anchor.removeAttribute('href');
-    });
+  private harden(contents: Contents): Promise<void> {
+    return sanitizeEpubDocument(contents.document);
   }
 
   private cfiToXPath(cfi: string, spineIndex: number): string | null {


### PR DESCRIPTION
## Problem
Rendered EPUB markup could retain remote resource URLs and unsafe navigation targets. Script execution was disabled, but images, stylesheets, CSS URLs, media, and malformed or encoded links were not comprehensively isolated.

## Change
- Sanitize rendered EPUB documents across anchors, resource attributes, `srcset`, inline CSS, stylesheets, and unsafe schemes.
- Preserve relative EPUB links, local app content bases, local assets, and safe embedded raster images.
- Sanitize local stylesheet text before reinserting it and add a restrictive in-document CSP with no network connections or scripts.
- Add hostile EPUB fixtures covering remote resources, encoded and malformed URLs, CSS imports, and safe internal/local content.

## Validation
- `npm test -- --run`
- `npm run check`
- `npm run lint`
- `npm run format:check`
