### PR TITLE
Harden the browser development proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,21 @@ npm run dev
 
 Use this for fast UI iteration and browser-based testing of the Svelte app. Native storage, downloads, and secure credential storage require Capacitor builds.
 
+When running the browser app against Kavita, the development proxy accepts
+loopback `http://` and `https://` targets such as `http://localhost:5000`. It
+rejects remote targets by default. To use a remote server, explicitly allow its
+HTTPS origin before starting Vite:
+
+```bash
+TURNLEAF_DEV_PROXY_ORIGINS="https://books.example.com:5000" npm run dev
+```
+
+The proxy accepts only HTTP(S), rejects URL credentials, forwards only the
+Kavita API headers it needs, limits request bodies to 1 MiB, and stops upstream
+requests after 12 seconds. It does not follow redirects or forward cookies,
+authorization, or forwarding headers. Plain HTTP is intentionally limited to
+loopback development servers.
+
 ### Quality checks
 
 ```bash

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@
 - Virtualize large library grids while preserving stable book ordering and touch scrolling.
 - Load library covers with bounded concurrency, cancel stale refresh work, and clean up browser cover URLs.
 - Make native library metadata refreshes transactional so failed updates leave the saved library unchanged.
+- Harden the browser development proxy with loopback and HTTPS origin controls, bounded requests, filtered credentials, and safe upstream failure handling.
 
 ## 0.3.2
 

--- a/scripts/dev-proxy.test.ts
+++ b/scripts/dev-proxy.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DevProxyError,
+  decodeProxyTarget,
+  fetchProxyTarget,
+  parseAllowedOrigins,
+  proxyRequestHeaders,
+  proxyResponseHeaders,
+  readProxyBody,
+  validateProxyTarget,
+} from './dev-proxy';
+
+function request(
+  method: string,
+  chunks: (Buffer | string)[],
+  headers: Record<string, string> = {},
+): Parameters<typeof readProxyBody>[0] {
+  return {
+    method,
+    headers,
+    async *[Symbol.asyncIterator]() {
+      yield* chunks;
+    },
+  };
+}
+
+describe('development proxy target validation', () => {
+  it('allows loopback HTTP and HTTPS targets', () => {
+    expect(validateProxyTarget('http://localhost:5000/api/Health')).toMatchObject({ ok: true });
+    expect(validateProxyTarget('https://127.0.0.1:5000/api/Health')).toMatchObject({ ok: true });
+    expect(validateProxyTarget('http://[::1]:5000/api/Health')).toMatchObject({ ok: true });
+  });
+
+  it('rejects malformed, non-HTTP, credentialed, and non-loopback targets', () => {
+    expect(() => decodeProxyTarget('%')).toThrowError(DevProxyError);
+    expect(decodeProxyTarget(encodeURIComponent('https://localhost:5000'))).toBe(
+      'https://localhost:5000',
+    );
+    expect(validateProxyTarget('not a URL')).toEqual({ ok: false, reason: 'malformed' });
+    expect(validateProxyTarget('file:///etc/passwd')).toEqual({ ok: false, reason: 'protocol' });
+    expect(validateProxyTarget('http://user:password@localhost:5000')).toEqual({
+      ok: false,
+      reason: 'credentials',
+    });
+    expect(validateProxyTarget('http://192.168.1.20:5000')).toEqual({
+      ok: false,
+      reason: 'origin',
+    });
+  });
+
+  it('allows an explicitly configured non-loopback origin', () => {
+    const allowed = parseAllowedOrigins(
+      'https://192.168.1.20:5000,http://192.168.1.21:5000,not-a-url,ftp://host',
+    );
+    expect(allowed).toEqual(new Set(['https://192.168.1.20:5000']));
+    expect(validateProxyTarget('https://192.168.1.20:5000/api/Health', allowed)).toMatchObject({
+      ok: true,
+    });
+    expect(validateProxyTarget('http://192.168.1.21:5000/api/Health', allowed)).toMatchObject({
+      ok: false,
+      reason: 'origin',
+    });
+  });
+});
+
+describe('development proxy request boundaries', () => {
+  it('forwards API headers while stripping browser and forwarding credentials', () => {
+    const headers = proxyRequestHeaders({
+      accept: 'application/json',
+      authorization: 'Bearer browser-secret',
+      connection: 'keep-alive',
+      cookie: 'session=secret',
+      'content-length': '12',
+      'content-type': 'application/json',
+      forwarded: 'for=127.0.0.1',
+      host: 'localhost:5173',
+      'x-api-key': 'kavita-key',
+      'x-forwarded-for': '127.0.0.1',
+    });
+
+    expect(headers.get('accept')).toBe('application/json');
+    expect(headers.get('content-type')).toBe('application/json');
+    expect(headers.get('x-api-key')).toBe('kavita-key');
+    expect(headers.get('authorization')).toBeNull();
+    expect(headers.get('cookie')).toBeNull();
+    expect(headers.get('forwarded')).toBeNull();
+    expect(headers.get('x-forwarded-for')).toBeNull();
+  });
+
+  it('limits request body size before buffering it', async () => {
+    await expect(readProxyBody(request('POST', ['12345']), 4)).rejects.toMatchObject({
+      statusCode: 413,
+    });
+    await expect(
+      readProxyBody(request('POST', ['12345'], { 'content-length': '5' }), 4),
+    ).rejects.toMatchObject({ statusCode: 413 });
+    await expect(readProxyBody(request('GET', ['ignored']), 1)).resolves.toBeUndefined();
+  });
+
+  it('converts redirects, timeouts, and upstream failures into safe proxy errors', async () => {
+    await expect(
+      fetchProxyTarget(
+        new URL('http://localhost:5000'),
+        {
+          method: 'GET',
+          headers: new Headers(),
+        },
+        {
+          fetchImpl: async () =>
+            new Response(null, { status: 302, headers: { location: 'https://evil.example' } }),
+        },
+      ),
+    ).rejects.toMatchObject({ statusCode: 502 });
+
+    await expect(
+      fetchProxyTarget(
+        new URL('http://localhost:5000'),
+        { method: 'GET' },
+        {
+          timeoutMs: 5,
+          fetchImpl: (_url, init) =>
+            new Promise((_resolve, reject) => {
+              init?.signal?.addEventListener('abort', () => reject(new DOMException('aborted')));
+            }),
+        },
+      ),
+    ).rejects.toMatchObject({ statusCode: 504 });
+
+    await expect(
+      fetchProxyTarget(
+        new URL('http://localhost:5000'),
+        { method: 'GET' },
+        {
+          fetchImpl: async () => {
+            throw new Error('offline');
+          },
+        },
+      ),
+    ).rejects.toMatchObject({ statusCode: 502 });
+  });
+
+  it('does not forward redirect or cookie response headers', () => {
+    const response = new Response('ok', {
+      status: 200,
+      headers: {
+        'content-type': 'text/plain',
+        location: 'https://evil.example',
+        'set-cookie': 'session=secret',
+      },
+    });
+
+    expect(proxyResponseHeaders(response)).toEqual([['content-type', 'text/plain']]);
+  });
+
+  it('uses the typed proxy error for invalid body lengths', async () => {
+    await expect(
+      readProxyBody(request('POST', [], { 'content-length': 'invalid' })),
+    ).rejects.toBeInstanceOf(DevProxyError);
+  });
+});

--- a/scripts/dev-proxy.ts
+++ b/scripts/dev-proxy.ts
@@ -1,0 +1,186 @@
+import { isIP } from 'node:net';
+import type { IncomingHttpHeaders, IncomingMessage, ServerResponse } from 'node:http';
+
+export const DEV_PROXY_PREFIX = '/__kavita__/';
+export const DEV_PROXY_ORIGINS_ENV = 'TURNLEAF_DEV_PROXY_ORIGINS';
+export const MAX_PROXY_BODY_BYTES = 1024 * 1024;
+export const PROXY_TIMEOUT_MS = 12_000;
+
+const ALLOWED_REQUEST_HEADERS = new Set(['accept', 'content-type', 'x-api-key']);
+const BLOCKED_RESPONSE_HEADERS = new Set([
+  'connection',
+  'content-encoding',
+  'content-length',
+  'location',
+  'set-cookie',
+  'transfer-encoding',
+]);
+
+export type ProxyTargetResult =
+  | { ok: true; url: URL }
+  | { ok: false; reason: 'malformed' | 'protocol' | 'credentials' | 'origin' };
+
+export class DevProxyError extends Error {
+  constructor(
+    readonly statusCode: 400 | 413 | 502 | 504,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+export function decodeProxyTarget(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    throw new DevProxyError(400, 'The Kavita development proxy target is malformed.');
+  }
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  const normalized = hostname.replace(/^\[|\]$/g, '').toLowerCase();
+  if (normalized === 'localhost' || normalized.endsWith('.localhost')) return true;
+  if (isIP(normalized) === 4) return normalized.split('.')[0] === '127';
+  return normalized === '::1';
+}
+
+function isHttpUrl(url: URL): boolean {
+  return url.protocol === 'http:' || url.protocol === 'https:';
+}
+
+export function parseAllowedOrigins(raw = process.env[DEV_PROXY_ORIGINS_ENV] ?? ''): Set<string> {
+  const origins = new Set<string>();
+  for (const value of raw.split(',')) {
+    const candidate = value.trim();
+    if (!candidate) continue;
+
+    try {
+      const url = new URL(candidate);
+      if (
+        url.protocol === 'https:' &&
+        !url.username &&
+        !url.password &&
+        url.pathname === '/' &&
+        !url.search &&
+        !url.hash
+      ) {
+        origins.add(url.origin);
+      }
+    } catch {
+      // Ignore malformed allowlist entries and keep the proxy fail-closed.
+    }
+  }
+  return origins;
+}
+
+export function validateProxyTarget(
+  value: string,
+  allowedOrigins: ReadonlySet<string> = parseAllowedOrigins(),
+): ProxyTargetResult {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return { ok: false, reason: 'malformed' };
+  }
+
+  if (!isHttpUrl(url)) return { ok: false, reason: 'protocol' };
+  if (url.username || url.password) return { ok: false, reason: 'credentials' };
+  if (
+    !isLoopbackHostname(url.hostname) &&
+    (url.protocol !== 'https:' || !allowedOrigins.has(url.origin))
+  ) {
+    return { ok: false, reason: 'origin' };
+  }
+  return { ok: true, url };
+}
+
+export function proxyRequestHeaders(source: IncomingHttpHeaders): Headers {
+  const headers = new Headers();
+  for (const [key, value] of Object.entries(source)) {
+    const lower = key.toLowerCase();
+    if (!ALLOWED_REQUEST_HEADERS.has(lower) || value == null) continue;
+    if (Array.isArray(value)) {
+      for (const item of value) headers.append(lower, item);
+    } else {
+      headers.set(lower, value);
+    }
+  }
+  return headers;
+}
+
+export async function readProxyBody(
+  req: Pick<IncomingMessage, 'method' | 'headers'> & AsyncIterable<Buffer | string>,
+  maxBytes = MAX_PROXY_BODY_BYTES,
+): Promise<Buffer | undefined> {
+  if (!req.method || req.method === 'GET' || req.method === 'HEAD') return undefined;
+
+  const contentLength = req.headers['content-length'];
+  if (typeof contentLength === 'string') {
+    const length = Number(contentLength);
+    if (!Number.isFinite(length) || length < 0) {
+      throw new DevProxyError(400, 'The request body length is invalid.');
+    }
+    if (length > maxBytes) {
+      throw new DevProxyError(413, 'The request body is too large for the development proxy.');
+    }
+  }
+
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of req) {
+    const buffer = typeof chunk === 'string' ? Buffer.from(chunk) : chunk;
+    total += buffer.byteLength;
+    if (total > maxBytes) {
+      throw new DevProxyError(413, 'The request body is too large for the development proxy.');
+    }
+    chunks.push(buffer);
+  }
+  return chunks.length ? Buffer.concat(chunks, total) : undefined;
+}
+
+export async function fetchProxyTarget(
+  target: URL,
+  init: RequestInit,
+  {
+    fetchImpl = fetch,
+    timeoutMs = PROXY_TIMEOUT_MS,
+  }: { fetchImpl?: typeof fetch; timeoutMs?: number } = {},
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetchImpl(target, {
+      ...init,
+      redirect: 'manual',
+      signal: controller.signal,
+    });
+    if (response.status >= 300 && response.status < 400) {
+      throw new DevProxyError(502, 'The Kavita development proxy does not follow redirects.');
+    }
+    return response;
+  } catch (error) {
+    if (error instanceof DevProxyError) throw error;
+    if (controller.signal.aborted) {
+      throw new DevProxyError(504, 'Kavita did not respond before the proxy timeout.');
+    }
+    throw new DevProxyError(502, 'Kavita could not be reached through the development proxy.');
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export function proxyResponseHeaders(response: Response): [string, string][] {
+  const headers: [string, string][] = [];
+  response.headers.forEach((value, key) => {
+    if (!BLOCKED_RESPONSE_HEADERS.has(key.toLowerCase())) headers.push([key, value]);
+  });
+  return headers;
+}
+
+export async function sendProxyResponse(res: ServerResponse, response: Response): Promise<void> {
+  res.statusCode = response.status;
+  for (const [key, value] of proxyResponseHeaders(response)) res.setHeader(key, value);
+  res.end(Buffer.from(await response.arrayBuffer()));
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,18 @@
 import tailwindcss from '@tailwindcss/vite';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { readFileSync } from 'node:fs';
-import type { IncomingMessage } from 'http';
 import { defineConfig, type Plugin } from 'vite';
+import {
+  DEV_PROXY_PREFIX,
+  decodeProxyTarget,
+  parseAllowedOrigins,
+  proxyRequestHeaders,
+  readProxyBody,
+  sendProxyResponse,
+  DevProxyError,
+  fetchProxyTarget,
+  validateProxyTarget,
+} from './scripts/dev-proxy';
 
 const packageJson = JSON.parse(
   readFileSync(new URL('./package.json', import.meta.url), 'utf8'),
@@ -12,64 +22,49 @@ const packageJson = JSON.parse(
 const appVersion = process.env.TURNLEAF_VERSION_NAME ?? packageJson.version;
 
 function kavitaDevProxy(): Plugin {
+  const allowedOrigins = parseAllowedOrigins();
+
   return {
     name: 'turnleaf-kavita-dev-proxy',
     configureServer(server) {
       server.middlewares.use(async (req, res, next) => {
-        if (!req.url?.startsWith('/__kavita__/')) {
+        if (!req.url?.startsWith(DEV_PROXY_PREFIX)) {
           next();
           return;
         }
 
-        const encodedTarget = req.url.slice('/__kavita__/'.length);
-        const target = decodeURIComponent(encodedTarget);
-        const body = await readBody(req);
-        const headers = new Headers();
-        for (const [key, value] of Object.entries(req.headers)) {
-          if (value == null) continue;
-          const lower = key.toLowerCase();
-          if (lower === 'host' || lower === 'content-length' || lower === 'connection') continue;
-          if (Array.isArray(value)) {
-            for (const item of value) headers.append(key, item);
-          } else {
-            headers.set(key, value);
+        try {
+          const encodedTarget = req.url.slice(DEV_PROXY_PREFIX.length);
+          const target = decodeProxyTarget(encodedTarget);
+          const targetResult = validateProxyTarget(target, allowedOrigins);
+          if (!targetResult.ok) {
+            throw new DevProxyError(400, 'The Kavita development proxy target is not allowed.');
           }
-        }
 
-        const response = await fetch(target, {
-          method: req.method,
-          headers,
-          body,
-          redirect: 'manual',
-        });
-
-        res.statusCode = response.status;
-        response.headers.forEach((value, key) => {
-          const lower = key.toLowerCase();
-          if (
-            lower === 'content-encoding' ||
-            lower === 'content-length' ||
-            lower === 'transfer-encoding' ||
-            lower === 'connection'
-          ) {
+          const body = await readProxyBody(req);
+          const response = await fetchProxyTarget(targetResult.url, {
+            method: req.method ?? 'GET',
+            headers: proxyRequestHeaders(req.headers),
+            body: body as unknown as BodyInit | undefined,
+          });
+          await sendProxyResponse(res, response);
+        } catch (error) {
+          if (res.headersSent) {
+            res.destroy();
             return;
           }
-          res.setHeader(key, value);
-        });
-        const buffer = Buffer.from(await response.arrayBuffer());
-        res.end(buffer);
+
+          const proxyError =
+            error instanceof DevProxyError
+              ? error
+              : new DevProxyError(502, 'The Kavita development proxy request failed.');
+          res.statusCode = proxyError.statusCode;
+          res.setHeader('content-type', 'text/plain; charset=utf-8');
+          res.end(proxyError.message);
+        }
       });
     },
   };
-}
-
-async function readBody(req: IncomingMessage): Promise<Buffer | undefined> {
-  if (!req.method || req.method === 'GET' || req.method === 'HEAD') return undefined;
-  const chunks: Buffer[] = [];
-  for await (const chunk of req) {
-    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : Buffer.from(chunk));
-  }
-  return chunks.length ? Buffer.concat(chunks) : undefined;
 }
 
 export default defineConfig({


### PR DESCRIPTION
## Summary

Harden the development-only Kavita browser proxy so it cannot act as an unrestricted open proxy. Loopback HTTP/HTTPS remains available for local Kavita instances; remote targets require an explicit HTTPS origin in `TURNLEAF_DEV_PROXY_ORIGINS`.

The proxy now rejects malformed URLs and credentials, forwards only the API headers it needs, caps request bodies at 1 MiB, times out upstream requests after 12 seconds, blocks redirects and sensitive response headers, and returns safe gateway errors. Focused tests cover the transport boundary and failure paths.

## Checks

- `npm run format:check`
- `npm run lint`
- `npm run check`
- `npm test` (79 tests)
- `npm run build`

## Security

- Cookies, authorization, forwarded, host, and connection headers are not forwarded.
- Remote HTTP origins are rejected; plain HTTP is limited to loopback development servers.
