### PR TITLE
perf: add native library title index

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - docs: add future implementation work plan
+- Add a native library index for server-scoped title queries.
 - Add accessible modal semantics, focus trapping, Escape/backdrop closing, and focus restoration to library and reader panels.
 - Add keyboard page navigation and an accessible reader shortcut hint for non-touch users.
 - Increase compact library controls to touch-friendly targets and expose reading progress to assistive technology.

--- a/src/lib/database/database.native.test.ts
+++ b/src/lib/database/database.native.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, expect, it, vi } from 'vitest';
 import type { capSQLiteChanges, capTask } from '@capacitor-community/sqlite';
 
 const mocks = vi.hoisted(() => {
-  let databaseVersion = 3;
+  let databaseVersion = 4;
   const executeTransaction = vi.fn<(tasks: capTask[]) => Promise<capSQLiteChanges>>(async () => ({
     changes: { changes: 0 },
   }));
@@ -24,7 +24,7 @@ const mocks = vi.hoisted(() => {
     db,
     executeTransaction,
     reset() {
-      databaseVersion = 3;
+      databaseVersion = 4;
       vi.clearAllMocks();
     },
     setDatabaseVersion(version: number) {
@@ -151,16 +151,18 @@ it('records each migration and its user version in one transaction', async () =>
 
   await openDatabase();
 
-  expect(mocks.executeTransaction).toHaveBeenCalledTimes(3);
+  expect(mocks.executeTransaction).toHaveBeenCalledTimes(4);
   const migrationTasks = mocks.executeTransaction.mock.calls.map(([tasks]) => tasks);
   expect(migrationTasks.map((tasks) => tasks?.[0]?.statement)).toEqual([
     expect.stringContaining('CREATE TABLE IF NOT EXISTS server_config'),
     expect.stringContaining('ALTER TABLE books ADD COLUMN pages'),
     expect.stringContaining('CREATE TABLE preferences'),
+    expect.stringContaining('CREATE INDEX IF NOT EXISTS idx_books_server_title'),
   ]);
   expect(migrationTasks.map((tasks) => tasks?.[1]?.statement)).toEqual([
     'PRAGMA user_version = 1;',
     'PRAGMA user_version = 2;',
     'PRAGMA user_version = 3;',
+    'PRAGMA user_version = 4;',
   ]);
 });

--- a/src/lib/database/schema.ts
+++ b/src/lib/database/schema.ts
@@ -78,4 +78,10 @@ export const migrations = [
       );
     `,
   },
+  {
+    version: 4,
+    statements: `
+      CREATE INDEX IF NOT EXISTS idx_books_server_title ON books(server_id, title);
+    `,
+  },
 ] as const;


### PR DESCRIPTION
Adds a versioned SQLite migration for the server/title lookup used by native library reads and covers the migration in native tests. This PR is limited to the query index and migration validation.