### PR TITLE
perf: update reader progress in memory

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - docs: add future implementation work plan
+- Update the changed book in memory after reader progress saves instead of reloading the full library.
 - Add accessible modal semantics, focus trapping, Escape/backdrop closing, and focus restoration to library and reader panels.
 - Add keyboard page navigation and an accessible reader shortcut hint for non-touch users.
 - Increase compact library controls to touch-friendly targets and expose reading progress to assistive technology.

--- a/src/lib/components/Library.svelte
+++ b/src/lib/components/Library.svelte
@@ -32,7 +32,7 @@
   import type { KavitaProgress } from '../kavita/types';
   import type { ReaderLocation } from '../reader/session';
   import { removeApiKey, saveApiKey } from '../native/credentials';
-  import { chooseOpenProgress, shouldPreferFurthest } from '../sync/conflict';
+  import { chooseOpenProgress, shouldPreferFurthest, toKavitaPageNumber } from '../sync/conflict';
   import { flushProgress } from '../sync/sync';
   import Reader from './Reader.svelte';
   import TurnleafLogo from './TurnleafLogo.svelte';
@@ -702,7 +702,9 @@
       location.percentage,
       location.spineIndex,
     );
-    books = await getBooks(server.id);
+    const pagesRead = toKavitaPageNumber(location.percentage, book.pages, location.spineIndex);
+    const lastReadAt = new Date().toISOString();
+    books = books.map((item) => (item.id === book.id ? { ...item, pagesRead, lastReadAt } : item));
     if (syncTimer !== null) window.clearTimeout(syncTimer);
     syncTimer = window.setTimeout(() => void flushProgress(client).catch(() => {}), 2_500);
   }


### PR DESCRIPTION
Updates the changed book in the library state after a local reader relocation instead of reloading every book from storage. The PR is limited to the per-page progress refresh path and preserves the existing durable save and sync scheduling.