### PR TITLE
fix: continue syncing after item failures

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - docs: add future implementation work plan
+- Continue syncing later progress items when an earlier item fails, while recording the failed item for retry.
 - Add accessible modal semantics, focus trapping, Escape/backdrop closing, and focus restoration to library and reader panels.
 - Add keyboard page navigation and an accessible reader shortcut hint for non-touch users.
 - Increase compact library controls to touch-friendly targets and expose reading progress to assistive technology.

--- a/src/lib/sync/sync.test.ts
+++ b/src/lib/sync/sync.test.ts
@@ -87,3 +87,39 @@ it('keeps a newer local queue item when an older upload completes', async () => 
   expect(saved.syncQueue['book-1']).toEqual(second.syncQueue['book-1']);
   expect(saved.readingState['book-1']?.pendingSync).toBe(true);
 });
+
+it('continues syncing later items when an earlier item fails', async () => {
+  type PendingFixture = ReturnType<typeof pendingState>;
+  type ExpandableFixture = Omit<PendingFixture, 'readingState' | 'syncQueue'> & {
+    readingState: Record<string, PendingFixture['readingState']['book-1']>;
+    syncQueue: Record<string, PendingFixture['syncQueue']['book-1']>;
+  };
+  const state = pendingState('2026-09-07T00:00:00.000Z', '{"pageNum":1}') as ExpandableFixture;
+  state.readingState['book-2'] = {
+    ...state.readingState['book-1']!,
+    localUpdatedAt: '2026-09-07T00:00:01.000Z',
+  };
+  state.syncQueue['book-2'] = {
+    ...state.syncQueue['book-1']!,
+    bookId: 'book-2',
+    payloadJson: '{"pageNum":2}',
+    createdAt: '2026-09-07T00:00:01.000Z',
+    updatedAt: '2026-09-07T00:00:01.000Z',
+  };
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+
+  const saveProgress = vi
+    .fn()
+    .mockRejectedValueOnce(new Error('first item failed'))
+    .mockResolvedValueOnce(undefined);
+
+  await expect(flushProgress({ saveProgress } as never)).rejects.toThrow(
+    '1 reading progress item failed to sync.',
+  );
+  expect(saveProgress).toHaveBeenCalledTimes(2);
+
+  const saved = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}') as typeof state;
+  expect(saved.syncQueue['book-1']?.lastError).toBe('first item failed');
+  expect(saved.syncQueue['book-2']).toBeUndefined();
+  expect(saved.readingState['book-2']?.pendingSync).toBe(false);
+});

--- a/src/lib/sync/sync.ts
+++ b/src/lib/sync/sync.ts
@@ -11,13 +11,20 @@ export function flushProgress(client: KavitaClient): Promise<void> {
 }
 
 async function run(client: KavitaClient): Promise<void> {
+  const failures: unknown[] = [];
   for (const item of await getPendingSync()) {
     try {
       await client.saveProgress(JSON.parse(item.payload) as KavitaProgress);
       await confirmSync(item.bookId, new Date().toISOString(), item.updatedAt);
     } catch (error) {
       await markSyncFailure(item.bookId, error instanceof Error ? error.message : 'Sync failed');
-      throw error;
+      failures.push(error);
     }
+  }
+  if (failures.length > 0) {
+    throw new AggregateError(
+      failures,
+      `${failures.length} reading progress item${failures.length === 1 ? '' : 's'} failed to sync.`,
+    );
   }
 }


### PR DESCRIPTION
Continues a sync batch after an individual progress upload fails, records the failed queue item for retry, and reports an aggregate failure after later items have had a chance to sync. This PR is limited to batch failure isolation.