### PR TITLE
Harden update links and Android release provenance

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -8,15 +8,23 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build-release-apk:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      release_tag: ${{ steps.release_version.outputs.release_tag }}
+      version_base: ${{ steps.release_version.outputs.version_base }}
+      tested_revision: ${{ steps.release_version.outputs.tested_revision }}
 
     steps:
       - name: Check out source
         uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v7
@@ -37,6 +45,7 @@ jobs:
         run: npm ci
 
       - name: Derive release version
+        id: release_version
         run: |
           set -eu
           BASE_VERSION="$(node -p "require('./package.json').version")"
@@ -45,12 +54,21 @@ jobs:
           echo "TURNLEAF_VERSION_NAME=${RELEASE_VERSION}" >> "$GITHUB_ENV"
           echo "TURNLEAF_VERSION_CODE=${GITHUB_RUN_NUMBER}" >> "$GITHUB_ENV"
           echo "TURNLEAF_RELEASE_TAG=v${RELEASE_VERSION}" >> "$GITHUB_ENV"
+          echo "release_tag=v${RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "version_base=${BASE_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tested_revision=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Finalize release notes
         run: npm run release:finalize
 
-      - name: Prepare release notes
-        run: npm run --silent release:notes > "$RUNNER_TEMP/turnleaf-release-notes.md"
+      - name: Run release quality gates
+        run: |
+          npm run security:audit
+          npm run format:check
+          npm run lint
+          npm run check
+          npm test
+          npm run android:debug
 
       - name: Restore signing key
         env:
@@ -87,12 +105,58 @@ jobs:
       - name: Build signed release APK
         run: npm run android:release
 
+      - name: Stage release artifacts and notes
+        run: |
+          set -eu
+          mkdir -p release-payload
+          APK="android/app/build/outputs/apk/release/app-release.apk"
+          test -f "$APK"
+          npm run --silent release:notes > "$RUNNER_TEMP/turnleaf-release-notes.md"
+          {
+            cat "$RUNNER_TEMP/turnleaf-release-notes.md"
+            printf '\n\nTested revision: `%s`\n' "$GITHUB_SHA"
+          } > release-payload/turnleaf-release-notes.md
+          cp "$APK" release-payload/app-release.apk
+          printf '%s\n' "$GITHUB_SHA" > release-payload/tested-revision.txt
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: turnleaf-release
+          path: release-payload
+          if-no-files-found: error
+
+  publish-github-release:
+    needs: build-release-apk
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download tested release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: turnleaf-release
+          path: release-payload
+
+      - name: Verify release provenance
+        env:
+          TESTED_REVISION: ${{ needs.build-release-apk.outputs.tested_revision }}
+        run: |
+          set -eu
+          test "$(cat release-payload/tested-revision.txt)" = "$TESTED_REVISION"
+          grep -Fq "Tested revision: \`$TESTED_REVISION\`" release-payload/turnleaf-release-notes.md
+          test -s release-payload/app-release.apk
+          test -s release-payload/turnleaf-release-notes.md
+
       - name: Publish GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.build-release-apk.outputs.release_tag }}
+          VERSION_BASE: ${{ needs.build-release-apk.outputs.version_base }}
+          TESTED_REVISION: ${{ needs.build-release-apk.outputs.tested_revision }}
         run: |
-          APK="android/app/build/outputs/apk/release/app-release.apk"
-          gh release create "$TURNLEAF_RELEASE_TAG" "$APK" \
-            --title "Turnleaf $TURNLEAF_VERSION_BASE" \
-            --notes-file "$RUNNER_TEMP/turnleaf-release-notes.md" \
-            --target "${{ github.sha }}"
+          gh release create "$RELEASE_TAG" "release-payload/app-release.apk" \
+            --title "Turnleaf $VERSION_BASE" \
+            --notes-file "release-payload/turnleaf-release-notes.md" \
+            --target "$TESTED_REVISION"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Harden release link validation and provenance
+- Validate GitHub update links and publish Android releases from tested revisions with least-privilege workflow permissions.
 - docs: add future implementation work plan
 - Add accessible modal semantics, focus trapping, Escape/backdrop closing, and focus restoration to library and reader panels.
 - Add keyboard page navigation and an accessible reader shortcut hint for non-touch users.

--- a/src/lib/github/releases.test.ts
+++ b/src/lib/github/releases.test.ts
@@ -1,5 +1,35 @@
-import { describe, expect, it } from 'vitest';
-import { compareVersions } from './releases';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { compareVersions, fetchLatestGithubRelease } from './releases';
+
+const trustedAsset = {
+  name: 'app-release.apk',
+  browser_download_url:
+    'https://github.com/sgerner/turnleaf/releases/download/v0.3.3%2B4/app-release.apk',
+};
+
+const trustedRelease = {
+  html_url: 'https://github.com/sgerner/turnleaf/releases/tag/v0.3.3%2B4',
+  name: 'Turnleaf 0.3.3',
+  tag_name: 'v0.3.3+4',
+  published_at: '2026-09-08T00:00:00Z',
+  draft: false,
+  prerelease: false,
+  assets: [trustedAsset],
+};
+
+function mockRelease(release: typeof trustedRelease) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => release,
+    }),
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe('compareVersions', () => {
   it('orders patch and minor versions', () => {
@@ -19,5 +49,65 @@ describe('compareVersions', () => {
 
   it('treats equal versions as equal', () => {
     expect(compareVersions('1.2.3', '1.2.3')).toBe(0);
+  });
+});
+
+describe('fetchLatestGithubRelease', () => {
+  it('keeps links for the expected GitHub release and APK asset', async () => {
+    mockRelease(trustedRelease);
+
+    await expect(fetchLatestGithubRelease('0.3.2')).resolves.toEqual({
+      version: '0.3.3+4',
+      releaseUrl: trustedRelease.html_url,
+      downloadUrl: trustedAsset.browser_download_url,
+      publishedAt: trustedRelease.published_at,
+      title: trustedRelease.name,
+    });
+  });
+
+  it.each([
+    'javascript:alert(1)',
+    'http://github.com/sgerner/turnleaf/releases/tag/v0.3.3%2B4',
+    'https://evil.example/releases/tag/v0.3.3%2B4',
+    'https://github.com/another/repository/releases/tag/v0.3.3%2B4',
+  ])('omits a banner when the release URL is unsafe or foreign: %s', async (htmlUrl) => {
+    mockRelease({ ...trustedRelease, html_url: htmlUrl });
+
+    await expect(fetchLatestGithubRelease('0.3.2')).resolves.toBeNull();
+  });
+
+  it.each([
+    'javascript:alert(1)',
+    'http://github.com/sgerner/turnleaf/releases/download/v0.3.3%2B4/app-release.apk',
+    'https://evil.example/releases/download/v0.3.3%2B4/app-release.apk',
+    'https://github.com/sgerner/other/releases/download/v0.3.3%2B4/app-release.apk',
+  ])('omits an unsafe or foreign APK URL: %s', async (browserDownloadUrl) => {
+    mockRelease({
+      ...trustedRelease,
+      assets: [{ ...trustedAsset, browser_download_url: browserDownloadUrl }],
+    });
+
+    await expect(fetchLatestGithubRelease('0.3.2')).resolves.toMatchObject({
+      releaseUrl: trustedRelease.html_url,
+      downloadUrl: null,
+    });
+  });
+
+  it('omits APK assets with path traversal or a mismatched asset path', async () => {
+    mockRelease({
+      ...trustedRelease,
+      assets: [
+        {
+          name: '../app-release.apk',
+          browser_download_url:
+            'https://github.com/sgerner/turnleaf/releases/download/v0.3.3%2B4/../app-release.apk',
+        },
+      ],
+    });
+
+    await expect(fetchLatestGithubRelease('0.3.2')).resolves.toMatchObject({
+      releaseUrl: trustedRelease.html_url,
+      downloadUrl: null,
+    });
   });
 });

--- a/src/lib/github/releases.ts
+++ b/src/lib/github/releases.ts
@@ -22,6 +22,7 @@ export type ReleaseBanner = {
 };
 
 const githubReleasesUrl = 'https://api.github.com/repos/sgerner/turnleaf/releases/latest';
+const githubRepositoryPath = '/sgerner/turnleaf';
 
 type ParsedVersion = {
   major: number;
@@ -35,7 +36,7 @@ function parseVersion(raw: string): ParsedVersion | null {
   const match = raw
     .trim()
     .replace(/^v/i, '')
-    .match(/^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+([0-9A-Za-z.-]+))?/);
+    .match(/^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+([0-9A-Za-z.-]+))?$/);
   if (!match) return null;
   return {
     major: Number(match[1]),
@@ -89,20 +90,67 @@ export function compareVersions(left: string, right: string): number {
   return compareSegments(a.build, b.build);
 }
 
-function pickDownloadUrl(release: GithubRelease): string | null {
-  const apkAsset = release.assets.find((asset) => asset.name.toLowerCase().endsWith('.apk'));
+function isTrustedGithubUrl(rawUrl: string, expectedPath: string): boolean {
+  try {
+    const url = new URL(rawUrl);
+    if (
+      url.protocol !== 'https:' ||
+      url.hostname.toLowerCase() !== 'github.com' ||
+      url.port ||
+      url.username ||
+      url.password ||
+      url.search ||
+      url.hash
+    ) {
+      return false;
+    }
+
+    return decodeURIComponent(url.pathname) === expectedPath;
+  } catch {
+    return false;
+  }
+}
+
+function isSafeAssetName(name: string): boolean {
+  return /^[A-Za-z0-9][A-Za-z0-9._-]*\.apk$/i.test(name);
+}
+
+function pickDownloadUrl(release: GithubRelease, tagName: string): string | null {
+  const assets = Array.isArray(release.assets) ? release.assets : [];
+  const apkAsset = assets.find((asset) => {
+    if (
+      !asset ||
+      typeof asset !== 'object' ||
+      typeof asset.name !== 'string' ||
+      typeof asset.browser_download_url !== 'string'
+    ) {
+      return false;
+    }
+    if (!isSafeAssetName(asset.name)) return false;
+
+    return isTrustedGithubUrl(
+      asset.browser_download_url,
+      `${githubRepositoryPath}/releases/download/${tagName}/${asset.name}`,
+    );
+  });
   return apkAsset?.browser_download_url ?? null;
 }
 
 function buildBanner(release: GithubRelease, currentVersion: string): ReleaseBanner | null {
-  const latestVersion = release.tag_name.trim().replace(/^v/i, '');
+  if (typeof release.tag_name !== 'string' || typeof release.html_url !== 'string') return null;
+
+  const tagName = release.tag_name.trim();
+  const latestVersion = tagName.replace(/^v/i, '');
   if (!parseVersion(latestVersion)) return null;
   if (compareVersions(latestVersion, currentVersion) <= 0) return null;
+  if (!isTrustedGithubUrl(release.html_url, `${githubRepositoryPath}/releases/tag/${tagName}`)) {
+    return null;
+  }
 
   return {
     version: latestVersion,
     releaseUrl: release.html_url,
-    downloadUrl: pickDownloadUrl(release),
+    downloadUrl: pickDownloadUrl(release, tagName),
     publishedAt: release.published_at,
     title: release.name,
   };


### PR DESCRIPTION
## Problem
The update banner trusted release and APK URLs returned by GitHub, and the Android release workflow published with write access before running the full release checks.

## Change
- Accept update links only over HTTPS on `github.com/sgerner/turnleaf`, with exact release-tag and APK-asset paths; unsafe or foreign URLs are omitted.
- Add release-link fixtures covering trusted, malformed, foreign, and traversal URLs.
- Run the PR quality gates and Android debug build on the exact checked-out revision before signing and publication.
- Isolate publication in a contents-write job, verify the tested revision, and include that revision in the release notes.
- Keep the existing default-branch push/manual-dispatch release policy unchanged.

## Validation
- `npm run check`
- `npm test -- src/lib/github/releases.test.ts` (14 tests)
- `npm test` (105 tests)
- `npm run lint`
- `npm run format:check`
- `npm audit --omit=dev --ignore-scripts` (0 vulnerabilities)
- `npm run android:debug`
- Workflow YAML parsed successfully
