### PR TITLE
Reconcile removed books and credential cleanup

### DIFF
--- a/OFFLINE_AND_SYNC.md
+++ b/OFFLINE_AND_SYNC.md
@@ -20,4 +20,13 @@ Flush triggers are connectivity restoration, app backgrounding, chapter change, 
 
 Reconciliation compares local and server locations with the last shared state. If both changed, reading pauses for an explicit choice. The furthest percentage never wins automatically.
 
+## Metadata refresh rule
+
+Only a fully fetched, successfully mapped Kavita metadata snapshot reconciles
+the local book rows. A missing remote book is removed when it has no local
+download and no pending progress; a downloaded book is kept and marked
+unavailable remotely so it remains readable offline. Pending progress is also
+retained and remains queued for retry. Empty, partial, failed, or cancelled
+fetches leave the previous local library unchanged.
+
 Kavita's `bookScrollId` is currently a content XPath. Turnleaf keeps CFI locally and sends a compatible XPath only after device/server validation confirms conversion for that EPUB.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Reconcile removed books and clean up credentials
+- Reconcile complete Kavita metadata snapshots without purging cached books after partial or failed fetches; retain downloaded books and pending local progress when Kavita removes them.
+- Report credential and server-configuration cleanup failures accurately and compensate failed onboarding saves so orphaned auth keys remain recoverable.
+- Document offline metadata retention and retry behavior.
 - docs: add future implementation work plan
 - Add accessible modal semantics, focus trapping, Escape/backdrop closing, and focus restoration to library and reader panels.
 - Add keyboard page navigation and an accessible reader shortcut hint for non-touch users.

--- a/src/lib/components/Library.svelte
+++ b/src/lib/components/Library.svelte
@@ -12,7 +12,7 @@
     markBookCompleted,
     removeDownload,
     removeServer,
-    replaceBooks,
+    reconcileBooks,
     saveLocalProgress,
     saveServer,
     setPreference,
@@ -210,9 +210,11 @@
       const matchesQuery = `${book.title} ${book.author ?? ''} ${book.series ?? ''}`
         .toLowerCase()
         .includes(query.trim().toLowerCase());
+      const retainedOffline = book.remoteAvailable === false && Boolean(book.downloadPath);
       const completed = book.pages > 0 && book.pagesRead >= book.pages;
       return (
         matchesQuery &&
+        (book.remoteAvailable !== false || retainedOffline) &&
         (!downloadedOnly || Boolean(book.downloadPath)) &&
         (!hideCompleted || !completed)
       );
@@ -255,6 +257,7 @@
   let replacingApiKey = $state(false);
   let deletingServer = $state(false);
   let confirmDeleteServer = $state(false);
+  let credentialCleanupComplete = false;
   let actionMenuBook = $state<BookRecord | null>(null);
   let actionMenuDialog = $state<HTMLElement | null>(null);
   let conflictDialog = $state<HTMLElement | null>(null);
@@ -496,7 +499,9 @@
         );
       }
       if (destroyed) return;
-      await replaceBooks(server.id, mapped);
+      // Reconcile only after every series page and detail batch completed.
+      // Errors and lifecycle cancellation leave the last known local library intact.
+      await reconcileBooks(server.id, mapped);
       if (destroyed) return;
       books = await getBooks(server.id);
       retainCoversFor(books);
@@ -860,14 +865,20 @@
       cancelCoverLoading();
       await clearCoverCache().catch(() => {});
       clearCovers();
-      await removeApiKey(server.credentialRef).catch(() => {});
+      if (!credentialCleanupComplete) {
+        await removeApiKey(server.credentialRef);
+        credentialCleanupComplete = true;
+      }
       await removeServer(server.id);
       onServerDeleted();
       message = 'Server removed. Add it again to browse the library.';
       closeSettings();
     } catch (cause) {
-      settingsError =
-        cause instanceof Error ? cause.message : 'Turnleaf could not remove the server.';
+      settingsError = credentialCleanupComplete
+        ? 'The auth key was removed, but the local server configuration could not be cleared. Retry Delete server to finish cleanup.'
+        : cause instanceof Error
+          ? `Could not remove the server safely: ${cause.message} The connection was left in place; retry Delete server.`
+          : 'Could not remove the server safely. The connection was left in place; retry Delete server.';
     } finally {
       deletingServer = false;
       confirmDeleteServer = false;
@@ -1147,6 +1158,20 @@
                         decoding="async"
                         alt=""
                       />
+                    {/if}
+                    {#if book.remoteAvailable === false && book.downloadPath}
+                      <span
+                        class="badge-icon preset-filled-warning-500 absolute left-2 top-2 h-7 w-7 p-0 shadow-md"
+                        title="Saved offline; no longer available on Kavita"
+                        aria-label="Saved offline; no longer available on Kavita"
+                      >
+                        <svg aria-hidden="true" viewBox="0 0 24 24" class="h-4 w-4">
+                          <path
+                            fill="currentColor"
+                            d="M12 2 1 21h22L12 2Zm0 4.2L19.5 19h-15L12 6.2ZM11 10v4h2v-4h-2Zm0 5v2h2v-2h-2Z"
+                          />
+                        </svg>
+                      </span>
                     {/if}
                     {#if downloadingBookId === book.id}
                       <span

--- a/src/lib/components/Onboarding.svelte
+++ b/src/lib/components/Onboarding.svelte
@@ -3,7 +3,7 @@
   import { saveServer, type ServerConfig } from '../database/database';
   import { KavitaClient, KavitaError } from '../kavita/client';
   import { normalizeServerUrl, ServerUrlError } from '../kavita/url';
-  import { saveApiKey } from '../native/credentials';
+  import { removeApiKey, saveApiKey } from '../native/credentials';
   import TurnleafLogo from './TurnleafLogo.svelte';
 
   let { onConnected }: { onConnected: (server: ServerConfig) => void } = $props();
@@ -49,9 +49,20 @@
       try {
         await saveServer(server);
       } catch (storageError) {
-        throw new Error('The connection worked, but local setup could not be saved.', {
-          cause: storageError,
-        });
+        try {
+          await removeApiKey(credentialRef);
+        } catch (cleanupError) {
+          throw new Error(
+            'The connection worked, but local setup could not be saved and the auth key could not be cleaned up. Retry setup or remove the server from settings.',
+            { cause: cleanupError },
+          );
+        }
+        throw new Error(
+          'The connection worked, but local setup could not be saved. No auth key was retained; try again.',
+          {
+            cause: storageError,
+          },
+        );
       }
       apiKey = '';
       onConnected(server);

--- a/src/lib/database/database.native.test.ts
+++ b/src/lib/database/database.native.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, expect, it, vi } from 'vitest';
 import type { capSQLiteChanges, capTask } from '@capacitor-community/sqlite';
 
 const mocks = vi.hoisted(() => {
-  let databaseVersion = 3;
+  let databaseVersion = 4;
   const executeTransaction = vi.fn<(tasks: capTask[]) => Promise<capSQLiteChanges>>(async () => ({
     changes: { changes: 0 },
   }));
@@ -24,7 +24,7 @@ const mocks = vi.hoisted(() => {
     db,
     executeTransaction,
     reset() {
-      databaseVersion = 3;
+      databaseVersion = 4;
       vi.clearAllMocks();
     },
     setDatabaseVersion(version: number) {
@@ -151,16 +151,18 @@ it('records each migration and its user version in one transaction', async () =>
 
   await openDatabase();
 
-  expect(mocks.executeTransaction).toHaveBeenCalledTimes(3);
+  expect(mocks.executeTransaction).toHaveBeenCalledTimes(4);
   const migrationTasks = mocks.executeTransaction.mock.calls.map(([tasks]) => tasks);
   expect(migrationTasks.map((tasks) => tasks?.[0]?.statement)).toEqual([
     expect.stringContaining('CREATE TABLE IF NOT EXISTS server_config'),
     expect.stringContaining('ALTER TABLE books ADD COLUMN pages'),
     expect.stringContaining('CREATE TABLE preferences'),
+    expect.stringContaining('ALTER TABLE books ADD COLUMN remote_available'),
   ]);
   expect(migrationTasks.map((tasks) => tasks?.[1]?.statement)).toEqual([
     'PRAGMA user_version = 1;',
     'PRAGMA user_version = 2;',
     'PRAGMA user_version = 3;',
+    'PRAGMA user_version = 4;',
   ]);
 });

--- a/src/lib/database/database.test.ts
+++ b/src/lib/database/database.test.ts
@@ -1,6 +1,12 @@
 import { expect, it, vi } from 'vitest';
 import type { capSQLiteChanges, capTask } from '@capacitor-community/sqlite';
-import { confirmSync, replaceBooksInTransaction, type BookRecord } from './database';
+import {
+  confirmSync,
+  reconcileBooks,
+  reconcileBooksInTransaction,
+  replaceBooksInTransaction,
+  type BookRecord,
+} from './database';
 
 const BROWSER_STORAGE_KEY = 'turnleaf_browser_database_v1';
 
@@ -138,7 +144,7 @@ it('commits metadata while preserving downloaded file state on existing books', 
   expect(tasks).toHaveLength(2);
   expect(tasks[0]?.statement).not.toContain('download_path=excluded');
   expect(tasks[0]?.statement).not.toContain('server_id=excluded');
-  expect(tasks[0]?.statement).not.toContain('reading_state');
+  expect(tasks[0]?.statement).toContain('pending_sync');
   expect(database.rows()[0]).toMatchObject({
     id: existingBook.id,
     title: 'New title',
@@ -211,4 +217,84 @@ it('does not acknowledge a queue item that was replaced while it uploaded', asyn
   await confirmSync('book-1', '2026-09-07T00:00:02.000Z', '2026-09-07T00:00:00.000Z');
 
   expect(JSON.parse(localStorage.getItem(BROWSER_STORAGE_KEY) ?? '{}')).toEqual(state);
+});
+
+it('reconciles removed browser books while retaining downloads and pending progress', async () => {
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: new MemoryStorage(),
+  });
+  const pendingBook: BookRecord = {
+    ...existingBook,
+    id: 'server:1:pending',
+    title: 'Pending book',
+    downloadPath: null,
+    downloadStatus: 'none',
+    fileSize: null,
+  };
+  const forgottenBook: BookRecord = {
+    ...existingBook,
+    id: 'server:1:forgotten',
+    title: 'Forgotten book',
+    downloadPath: null,
+    downloadStatus: 'none',
+    fileSize: null,
+  };
+  localStorage.setItem(
+    BROWSER_STORAGE_KEY,
+    JSON.stringify({
+      serverConfig: null,
+      books: [existingBook, pendingBook, forgottenBook],
+      readingState: {
+        [pendingBook.id]: {
+          cfi: 'cfi',
+          xpath: null,
+          percentage: 0.5,
+          localUpdatedAt: '2026-09-07T00:00:01.000Z',
+          serverUpdatedAt: null,
+          pendingSync: true,
+        },
+      },
+      syncQueue: {},
+      preferences: {},
+    }),
+  );
+
+  await reconcileBooks('server', [
+    { ...forgottenBook, id: 'server:1:new', title: 'New book', remoteAvailable: true },
+  ]);
+
+  const saved = JSON.parse(localStorage.getItem(BROWSER_STORAGE_KEY) ?? '{}') as {
+    books: BookRecord[];
+  };
+  expect(saved.books.map((book) => book.id)).toEqual([
+    'server:1:new',
+    existingBook.id,
+    pendingBook.id,
+  ]);
+  expect(saved.books.find((book) => book.id === existingBook.id)).toMatchObject({
+    remoteAvailable: false,
+    downloadPath: existingBook.downloadPath,
+  });
+  expect(saved.books.find((book) => book.id === pendingBook.id)).toMatchObject({
+    remoteAvailable: false,
+  });
+});
+
+it('reconciles an empty native snapshot without deleting retained rows', async () => {
+  const executeTransaction = vi.fn(async (_tasks: capTask[]) => ({ changes: { changes: 0 } }));
+
+  await reconcileBooksInTransaction(
+    { executeTransaction },
+    'server',
+    [],
+    '2026-09-07T00:00:00.000Z',
+  );
+
+  const [tasks] = executeTransaction.mock.calls[0] ?? [];
+  expect(tasks).toHaveLength(2);
+  expect(tasks?.[0]?.statement).toContain('remote_available=0');
+  expect(tasks?.[0]?.statement).toContain('download_path IS NOT NULL');
+  expect(tasks?.[1]?.statement).toContain('DELETE FROM books');
+  expect(tasks?.[1]?.statement).toContain('NOT (');
 });

--- a/src/lib/database/database.ts
+++ b/src/lib/database/database.ts
@@ -36,6 +36,8 @@ export interface BookRecord {
   downloadPath: string | null;
   downloadStatus: string;
   fileSize: number | null;
+  /** False means Kavita no longer advertises the book; local retention may keep it. */
+  remoteAvailable?: boolean;
 }
 
 let connection: SQLiteDBConnection | null = null;
@@ -80,7 +82,12 @@ function readBrowserState(): BrowserDatabaseState {
     const parsed = JSON.parse(raw) as Partial<BrowserDatabaseState>;
     return {
       serverConfig: parsed.serverConfig ?? null,
-      books: Array.isArray(parsed.books) ? (parsed.books as BookRecord[]) : [],
+      books: Array.isArray(parsed.books)
+        ? (parsed.books as BookRecord[]).map((book) => ({
+            ...book,
+            remoteAvailable: book.remoteAvailable !== false,
+          }))
+        : [],
       readingState: parsed.readingState ?? {},
       syncQueue: parsed.syncQueue ?? {},
       preferences: parsed.preferences ?? {},
@@ -218,26 +225,79 @@ export async function getServer(): Promise<ServerConfig | null> {
   };
 }
 
-export async function replaceBooks(serverId: string, books: BookRecord[]): Promise<void> {
+/**
+ * Reconcile a complete, successful Kavita metadata snapshot. Books that are
+ * gone remotely are removed unless they have a retained download or pending
+ * local progress; retained rows are marked unavailable until Kavita advertises
+ * them again. Callers must not invoke this for partial or failed snapshots.
+ */
+export async function reconcileBooks(serverId: string, books: BookRecord[]): Promise<void> {
   if (!Capacitor.isNativePlatform()) {
     const state = readBrowserState();
-    state.books = books.map((book) => ({ ...book, serverId }));
+    const incoming = new Map(books.map((book) => [book.id, { ...book, serverId }]));
+    const existing = state.books.filter((book) => book.serverId === serverId);
+    const retained = existing
+      .filter(
+        (book) =>
+          !incoming.has(book.id) &&
+          (Boolean(book.downloadPath) ||
+            book.downloadStatus === 'available' ||
+            Boolean(state.syncQueue[book.id]) ||
+            state.readingState[book.id]?.pendingSync === true),
+      )
+      .map((book) => ({ ...book, remoteAvailable: false }));
+    const merged = [...incoming.values()].map((book) => {
+      const previous = existing.find((item) => item.id === book.id);
+      if (!previous) return { ...book, remoteAvailable: true };
+      const pending =
+        Boolean(state.syncQueue[book.id]) || state.readingState[book.id]?.pendingSync === true;
+      return {
+        ...previous,
+        ...book,
+        serverId,
+        remoteAvailable: true,
+        downloadPath: previous.downloadPath,
+        downloadStatus: previous.downloadStatus,
+        fileSize: previous.fileSize,
+        pagesRead: pending ? previous.pagesRead : book.pagesRead,
+        lastReadAt: pending ? previous.lastReadAt : book.lastReadAt,
+      };
+    });
+    state.books = [
+      ...state.books.filter((book) => book.serverId !== serverId),
+      ...merged,
+      ...retained,
+    ];
     writeBrowserState(state);
     return;
   }
-  await replaceBooksInTransaction(await openDatabase(), serverId, books);
+  await reconcileBooksInTransaction(await openDatabase(), serverId, books);
 }
+
+/** Backward-compatible name for callers that already pass a complete snapshot. */
+export const replaceBooks = reconcileBooks;
 
 const replaceBookStatement = `INSERT INTO books
   (id, server_id, library_id, series_id, volume_id, chapter_id, title, author, series,
    description_html, format, metadata_refreshed_at, download_path, download_status, file_size,
-   pages, pages_read, created_at, last_read_at)
-  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+   pages, pages_read, created_at, last_read_at, remote_available)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   ON CONFLICT(id) DO UPDATE SET
    title=excluded.title, author=excluded.author, series=excluded.series,
    description_html=excluded.description_html, format=excluded.format,
    metadata_refreshed_at=excluded.metadata_refreshed_at, pages=excluded.pages,
-   pages_read=excluded.pages_read, created_at=excluded.created_at, last_read_at=excluded.last_read_at`;
+   pages_read=CASE WHEN EXISTS (
+     SELECT 1 FROM reading_state WHERE book_id=excluded.id AND pending_sync=1
+   ) OR EXISTS (
+     SELECT 1 FROM sync_queue WHERE book_id=excluded.id
+   ) THEN books.pages_read ELSE excluded.pages_read END,
+   created_at=excluded.created_at,
+   last_read_at=CASE WHEN EXISTS (
+     SELECT 1 FROM reading_state WHERE book_id=excluded.id AND pending_sync=1
+   ) OR EXISTS (
+     SELECT 1 FROM sync_queue WHERE book_id=excluded.id
+   ) THEN books.last_read_at ELSE excluded.last_read_at END,
+   remote_available=excluded.remote_available`;
 
 function replaceBookTask(serverId: string, book: BookRecord, refreshedAt: string): capTask {
   return {
@@ -262,6 +322,7 @@ function replaceBookTask(serverId: string, book: BookRecord, refreshedAt: string
       book.pagesRead,
       book.createdAt,
       book.lastReadAt,
+      book.remoteAvailable !== false ? 1 : 0,
     ],
   };
 }
@@ -279,6 +340,36 @@ export async function replaceBooksInTransaction(
 ): Promise<void> {
   if (books.length === 0) return;
   await db.executeTransaction(books.map((book) => replaceBookTask(serverId, book, refreshedAt)));
+}
+
+const retainedBookCondition = `(download_path IS NOT NULL OR download_status='available'
+  OR EXISTS (SELECT 1 FROM reading_state WHERE reading_state.book_id=books.id
+    AND reading_state.pending_sync=1)
+  OR EXISTS (SELECT 1 FROM sync_queue WHERE sync_queue.book_id=books.id))`;
+
+/** Apply metadata and removal reconciliation atomically on native SQLite. */
+export async function reconcileBooksInTransaction(
+  db: Pick<SQLiteDBConnection, 'executeTransaction'>,
+  serverId: string,
+  books: BookRecord[],
+  refreshedAt = new Date().toISOString(),
+): Promise<void> {
+  const ids = books.map((book) => book.id);
+  const absent = ids.length ? `id NOT IN (${ids.map(() => '?').join(',')})` : '1=1';
+  const values = [serverId, ...ids];
+  await db.executeTransaction([
+    ...books.map((book) => replaceBookTask(serverId, book, refreshedAt)),
+    {
+      statement: `UPDATE books SET remote_available=0 WHERE server_id=? AND ${absent}
+        AND ${retainedBookCondition}`,
+      values,
+    },
+    {
+      statement: `DELETE FROM books WHERE server_id=? AND ${absent}
+        AND NOT ${retainedBookCondition}`,
+      values,
+    },
+  ]);
 }
 
 export async function getBooks(serverId: string): Promise<BookRecord[]> {
@@ -308,6 +399,7 @@ export async function getBooks(serverId: string): Promise<BookRecord[]> {
     downloadPath: row.download_path ? String(row.download_path) : null,
     downloadStatus: String(row.download_status),
     fileSize: row.file_size == null ? null : Number(row.file_size),
+    remoteAvailable: Number(row.remote_available ?? 1) !== 0,
   }));
 }
 

--- a/src/lib/database/schema.ts
+++ b/src/lib/database/schema.ts
@@ -78,4 +78,10 @@ export const migrations = [
       );
     `,
   },
+  {
+    version: 4,
+    statements: `
+      ALTER TABLE books ADD COLUMN remote_available INTEGER NOT NULL DEFAULT 1;
+    `,
+  },
 ] as const;

--- a/src/lib/kavita/client.test.ts
+++ b/src/lib/kavita/client.test.ts
@@ -105,6 +105,21 @@ it('loads every series page for large libraries', async () => {
   );
 });
 
+it('rejects an incomplete series page instead of treating it as an empty library', async () => {
+  vi.mocked(fetch).mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    headers: { get: () => null },
+    json: async () => ({ unexpected: true }),
+  } as unknown as Response);
+
+  await expect(
+    new KavitaClient('https://books.example.com', 'abc123').getBookSeries(),
+  ).rejects.toMatchObject({
+    kind: 'invalid-response',
+  });
+});
+
 it.each([[[2, 4]], [[4]]])(
   'connects to supported EPUB library types %j',
   async (supportedTypes) => {

--- a/src/lib/kavita/client.ts
+++ b/src/lib/kavita/client.ts
@@ -65,6 +65,9 @@ export class KavitaClient {
         `/api/Series/v2?PageNumber=${pageNumber}&PageSize=${SERIES_PAGE_SIZE}`,
         options,
       );
+      if (!Array.isArray(page)) {
+        throw new KavitaError('Kavita returned an unexpected series response.', 'invalid-response');
+      }
       series.push(...page);
       if (page.length < SERIES_PAGE_SIZE) break;
     }

--- a/src/lib/kavita/mapper.ts
+++ b/src/lib/kavita/mapper.ts
@@ -54,6 +54,7 @@ function mapChapterToBook(
     downloadPath: null,
     downloadStatus: 'none',
     fileSize: file.bytes,
+    remoteAvailable: true,
   };
 }
 

--- a/src/lib/native/credentials.test.ts
+++ b/src/lib/native/credentials.test.ts
@@ -1,0 +1,23 @@
+import { expect, it, vi } from 'vitest';
+
+const secureStorage = vi.hoisted(() => ({
+  setKeyPrefix: vi.fn(async () => undefined),
+  setSynchronize: vi.fn(async () => undefined),
+  remove: vi.fn(async () => undefined),
+}));
+
+vi.mock('@capacitor/core', () => ({
+  Capacitor: { isNativePlatform: () => true },
+}));
+
+vi.mock('@aparajita/capacitor-secure-storage', () => ({ SecureStorage: secureStorage }));
+
+it('reports secure-storage deletion failures without hiding them', async () => {
+  secureStorage.remove.mockRejectedValueOnce(new Error('keystore locked'));
+  const { removeApiKey } = await import('./credentials');
+
+  await expect(removeApiKey('server_primary_api_key')).rejects.toThrow(
+    'Could not remove the saved Kavita auth key.',
+  );
+  expect(secureStorage.remove).toHaveBeenCalledWith('server_primary_api_key');
+});

--- a/src/lib/native/credentials.ts
+++ b/src/lib/native/credentials.ts
@@ -51,5 +51,9 @@ export async function removeApiKey(reference: string): Promise<void> {
     return;
   }
   await prepare();
-  await SecureStorage.remove(reference);
+  try {
+    await SecureStorage.remove(reference);
+  } catch (error) {
+    throw new Error('Could not remove the saved Kavita auth key.', { cause: error });
+  }
 }


### PR DESCRIPTION
## Summary

Turnleaf now reconciles only complete Kavita metadata snapshots. Remote removals delete unretained rows, while downloaded books and pending progress remain local and are marked unavailable until they return. Malformed series pages fail before reconciliation, so partial, empty-on-error, and network/auth failures do not purge saved metadata.

Onboarding compensates a failed server configuration write by removing the newly stored key, and reports when that cleanup also fails. Server deletion now surfaces secure-storage and configuration cleanup failures and can retry the remaining stage.

## Validation

- `npm test` (99 tests)
- `npm run check`
- `npm run lint`
- `npm run format:check`
