### PR TITLE
Validate EPUB downloads and Kavita payloads

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate downloaded EPUB ZIP containers with bounded range reads and reject malformed or unsafe archives before making them available; validate Kavita library, series, detail, progress, and paginated response shapes without replacing saved offline data after a failed refresh.
 - docs: add future implementation work plan
 - Add accessible modal semantics, focus trapping, Escape/backdrop closing, and focus restoration to library and reader panels.
 - Add keyboard page navigation and an accessible reader shortcut hint for non-touch users.

--- a/src/lib/downloads/epub-validation.test.ts
+++ b/src/lib/downloads/epub-validation.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  EpubValidationError,
+  MAX_EPUB_ENTRIES,
+  MAX_EPUB_EXPANDED_SIZE,
+  MAX_EPUB_FILE_SIZE,
+  validateEpubArchive,
+} from './epub-validation';
+
+interface ZipTestEntry {
+  name: string;
+  data?: Uint8Array;
+  declaredSize?: number;
+}
+
+function write16(bytes: Uint8Array, offset: number, value: number): void {
+  bytes[offset] = value & 0xff;
+  bytes[offset + 1] = (value >>> 8) & 0xff;
+}
+
+function write32(bytes: Uint8Array, offset: number, value: number): void {
+  write16(bytes, offset, value);
+  write16(bytes, offset + 2, value / 0x10000);
+}
+
+function makeZip(entries: ZipTestEntry[]): Uint8Array {
+  const normalized = entries.map((entry) => ({
+    name: new TextEncoder().encode(entry.name),
+    data: entry.data ?? new Uint8Array(),
+    declaredSize: entry.declaredSize ?? entry.data?.length ?? 0,
+  }));
+  const localSize = normalized.reduce(
+    (total, entry) => total + 30 + entry.name.length + entry.data.length,
+    0,
+  );
+  const centralSize = normalized.reduce((total, entry) => total + 46 + entry.name.length, 0);
+  const archive = new Uint8Array(localSize + centralSize + 22);
+  let offset = 0;
+  const localOffsets: number[] = [];
+  for (const entry of normalized) {
+    localOffsets.push(offset);
+    write32(archive, offset, 0x04034b50);
+    write16(archive, offset + 4, 20);
+    write16(archive, offset + 26, entry.name.length);
+    offset += 30;
+    archive.set(entry.name, offset);
+    offset += entry.name.length;
+    archive.set(entry.data, offset);
+    offset += entry.data.length;
+  }
+  const centralOffset = offset;
+  normalized.forEach((entry, index) => {
+    write32(archive, offset, 0x02014b50);
+    write16(archive, offset + 4, 20);
+    write16(archive, offset + 6, 20);
+    write16(archive, offset + 28, entry.name.length);
+    write32(archive, offset + 20, entry.data.length);
+    write32(archive, offset + 24, entry.declaredSize);
+    write32(archive, offset + 42, localOffsets[index]!);
+    offset += 46;
+    archive.set(entry.name, offset);
+    offset += entry.name.length;
+  });
+  write32(archive, offset, 0x06054b50);
+  write16(archive, offset + 8, normalized.length);
+  write16(archive, offset + 10, normalized.length);
+  write32(archive, offset + 12, centralSize);
+  write32(archive, offset + 16, centralOffset);
+  return archive;
+}
+
+function validEntries(extra: ZipTestEntry[] = []): ZipTestEntry[] {
+  return [
+    { name: 'mimetype', data: new TextEncoder().encode('application/epub+zip') },
+    {
+      name: 'META-INF/container.xml',
+      data: new TextEncoder().encode(
+        '<container><rootfiles><rootfile full-path="OEBPS/content.opf"/></rootfiles></container>',
+      ),
+    },
+    { name: 'OEBPS/cover.jpg', data: new Uint8Array(100_000) },
+    ...extra,
+  ];
+}
+
+async function expectInvalid(archive: Uint8Array, fileSize = archive.length): Promise<void> {
+  await expect(
+    validateEpubArchive(fileSize, async (offset, length) => archive.slice(offset, offset + length)),
+  ).rejects.toBeInstanceOf(EpubValidationError);
+}
+
+describe('EPUB container validation', () => {
+  it('accepts a valid illustrated EPUB while using bounded range reads', async () => {
+    const archive = makeZip(validEntries());
+    const reads: Array<{ offset: number; length: number }> = [];
+    await validateEpubArchive(archive.length, async (offset, length) => {
+      reads.push({ offset, length });
+      return archive.slice(offset, offset + length);
+    });
+
+    expect(reads.length).toBe(5);
+    expect(Math.max(...reads.map((read) => read.length))).toBeLessThan(archive.length);
+  });
+
+  it('rejects an HTML error body, even when it is larger than the old size check', async () => {
+    const body = new TextEncoder().encode(`<html>${'error '.repeat(20)}</html>`);
+    await expectInvalid(body);
+  });
+
+  it('rejects truncated ZIP data and a missing container entry', async () => {
+    const archive = makeZip(validEntries());
+    await expectInvalid(archive.slice(0, -3), archive.length);
+    await expectInvalid(
+      makeZip([{ name: 'mimetype', data: new TextEncoder().encode('application/epub+zip') }]),
+    );
+  });
+
+  it('rejects malformed container XML even when the ZIP structure is intact', async () => {
+    await expectInvalid(
+      makeZip([
+        { name: 'mimetype', data: new TextEncoder().encode('application/epub+zip') },
+        { name: 'META-INF/container.xml', data: new TextEncoder().encode('<container>') },
+      ]),
+    );
+  });
+
+  it('rejects path traversal and excessive entry counts', async () => {
+    await expectInvalid(
+      makeZip(validEntries([{ name: '../outside.xhtml', data: new Uint8Array([1]) }])),
+    );
+    const entries = Array.from({ length: MAX_EPUB_ENTRIES - 1 }, (_, index) => ({
+      name: `OEBPS/page-${index}.xhtml`,
+      data: new Uint8Array([1]),
+    }));
+    await expectInvalid(makeZip(validEntries(entries)));
+  });
+
+  it('rejects an archive whose declared expanded size exceeds the bound', async () => {
+    const archive = makeZip(
+      validEntries([
+        {
+          name: 'OEBPS/huge.bin',
+          data: new Uint8Array([1]),
+          declaredSize: MAX_EPUB_EXPANDED_SIZE,
+        },
+      ]),
+    );
+    await expectInvalid(archive);
+  });
+
+  it('rejects an oversized file before reading any bytes', async () => {
+    const readRange = vi.fn(async () => new Uint8Array());
+    await expect(validateEpubArchive(MAX_EPUB_FILE_SIZE + 1, readRange)).rejects.toBeInstanceOf(
+      EpubValidationError,
+    );
+    expect(readRange).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/downloads/epub-validation.ts
+++ b/src/lib/downloads/epub-validation.ts
@@ -1,0 +1,393 @@
+const ZIP_END_OF_CENTRAL_DIRECTORY = 0x06054b50;
+const ZIP_CENTRAL_DIRECTORY_ENTRY = 0x02014b50;
+const ZIP_LOCAL_FILE_HEADER = 0x04034b50;
+const ZIP_END_OF_CENTRAL_DIRECTORY_LENGTH = 22;
+const ZIP_MAX_COMMENT_LENGTH = 0xffff;
+
+/** Maximum native file size that Turnleaf will make available as an EPUB. */
+export const MAX_EPUB_FILE_SIZE = 512 * 1024 * 1024;
+/** Maximum uncompressed size represented by an EPUB's central directory. */
+export const MAX_EPUB_EXPANDED_SIZE = 1024 * 1024 * 1024;
+/** Keep central-directory inspection bounded even for a hostile entry count. */
+export const MAX_EPUB_ENTRIES = 10_000;
+export const MAX_EPUB_CENTRAL_DIRECTORY_SIZE = 16 * 1024 * 1024;
+const MAX_CONTAINER_XML_SIZE = 1024 * 1024;
+const INITIAL_READ_SIZE = 4096;
+const ZIP_TAIL_READ_SIZE = ZIP_END_OF_CENTRAL_DIRECTORY_LENGTH + ZIP_MAX_COMMENT_LENGTH;
+
+export interface EpubArchiveEntry {
+  name: string;
+  flags: number;
+  compressionMethod: number;
+  compressedSize: number;
+  uncompressedSize: number;
+  localHeaderOffset: number;
+}
+
+export interface EpubRangeReader {
+  (offset: number, length: number): Promise<Uint8Array>;
+}
+
+export class EpubValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'EpubValidationError';
+  }
+}
+
+function readUint16(bytes: Uint8Array, offset: number): number {
+  return bytes[offset]! | (bytes[offset + 1]! << 8);
+}
+
+function readUint32(bytes: Uint8Array, offset: number): number {
+  return (
+    (bytes[offset]! |
+      (bytes[offset + 1]! << 8) |
+      (bytes[offset + 2]! << 16) |
+      (bytes[offset + 3]! << 24)) >>>
+    0
+  );
+}
+
+function hasSignature(bytes: Uint8Array, offset: number, signature: number): boolean {
+  return offset >= 0 && offset + 4 <= bytes.length && readUint32(bytes, offset) === signature;
+}
+
+function decodeName(bytes: Uint8Array, utf8: boolean): string {
+  try {
+    return new TextDecoder('utf-8', { fatal: utf8 }).decode(bytes);
+  } catch {
+    throw new EpubValidationError('The EPUB contains an invalid filename encoding.');
+  }
+}
+
+function validatePath(name: string): void {
+  if (!name || name.includes('\\') || name.startsWith('/') || /^[A-Za-z]:/.test(name)) {
+    throw new EpubValidationError('The EPUB contains an unsafe archive path.');
+  }
+  const segments = name.split('/');
+  for (const [index, segment] of segments.entries()) {
+    if (segment === '' && index !== segments.length - 1) {
+      throw new EpubValidationError('The EPUB contains a malformed archive path.');
+    }
+    if (segment === '.' || segment === '..') {
+      throw new EpubValidationError('The EPUB contains a path traversal entry.');
+    }
+    if (
+      [...segment].some((character) => {
+        const code = character.charCodeAt(0);
+        return code < 0x20 || code === 0x7f;
+      })
+    ) {
+      throw new EpubValidationError('The EPUB contains an invalid archive path.');
+    }
+  }
+}
+
+function requireRange(bytes: Uint8Array, expectedLength: number, message: string): void {
+  if (bytes.length !== expectedLength) throw new EpubValidationError(message);
+}
+
+function parseCentralDirectory(
+  bytes: Uint8Array,
+  expectedEntries: number,
+  archiveOffset: number,
+): EpubArchiveEntry[] {
+  const entries: EpubArchiveEntry[] = [];
+  const names = new Set<string>();
+  const localOffsets = new Set<number>();
+  let offset = 0;
+
+  for (let index = 0; index < expectedEntries; index += 1) {
+    if (!hasSignature(bytes, offset, ZIP_CENTRAL_DIRECTORY_ENTRY)) {
+      throw new EpubValidationError('The EPUB central directory is malformed.');
+    }
+    if (offset + 46 > bytes.length) {
+      throw new EpubValidationError('The EPUB central directory is truncated.');
+    }
+
+    const flags = readUint16(bytes, offset + 8);
+    const compressionMethod = readUint16(bytes, offset + 10);
+    const compressedSize = readUint32(bytes, offset + 20);
+    const uncompressedSize = readUint32(bytes, offset + 24);
+    const nameLength = readUint16(bytes, offset + 28);
+    const extraLength = readUint16(bytes, offset + 30);
+    const commentLength = readUint16(bytes, offset + 32);
+    const diskNumber = readUint16(bytes, offset + 34);
+    const localHeaderOffset = readUint32(bytes, offset + 42);
+    const recordLength = 46 + nameLength + extraLength + commentLength;
+    if (offset + recordLength > bytes.length) {
+      throw new EpubValidationError('The EPUB central directory entry is truncated.');
+    }
+    if (diskNumber !== 0 || compressedSize === 0xffffffff || uncompressedSize === 0xffffffff) {
+      throw new EpubValidationError('The EPUB uses an unsupported ZIP layout.');
+    }
+    if (flags & 0x1 || flags & 0x40 || (compressionMethod !== 0 && compressionMethod !== 8)) {
+      throw new EpubValidationError('The EPUB uses an unsupported or encrypted ZIP entry.');
+    }
+
+    const name = decodeName(
+      bytes.subarray(offset + 46, offset + 46 + nameLength),
+      Boolean(flags & 0x800),
+    );
+    validatePath(name);
+    if (names.has(name))
+      throw new EpubValidationError('The EPUB contains duplicate archive paths.');
+    names.add(name);
+    if (localOffsets.has(localHeaderOffset)) {
+      throw new EpubValidationError('The EPUB contains overlapping local file headers.');
+    }
+    localOffsets.add(localHeaderOffset);
+
+    if (localHeaderOffset > archiveOffset - 30) {
+      throw new EpubValidationError('The EPUB contains an out-of-bounds local file header.');
+    }
+    if (localHeaderOffset + 30 + compressedSize > archiveOffset) {
+      throw new EpubValidationError('The EPUB contains a truncated file entry.');
+    }
+
+    entries.push({
+      name,
+      flags,
+      compressionMethod,
+      compressedSize,
+      uncompressedSize,
+      localHeaderOffset,
+    });
+    offset += recordLength;
+  }
+
+  if (offset !== bytes.length) {
+    throw new EpubValidationError('The EPUB central directory contains trailing data.');
+  }
+  return entries;
+}
+
+function validateMimetypeEntry(head: Uint8Array, entry: EpubArchiveEntry): void {
+  if (
+    entry.name !== 'mimetype' ||
+    entry.localHeaderOffset !== 0 ||
+    entry.compressionMethod !== 0 ||
+    entry.flags !== 0 ||
+    entry.compressedSize !== 20 ||
+    entry.uncompressedSize !== 20
+  ) {
+    throw new EpubValidationError('The EPUB must begin with an uncompressed mimetype entry.');
+  }
+  if (!hasSignature(head, 0, ZIP_LOCAL_FILE_HEADER) || head.length < 30) {
+    throw new EpubValidationError('The EPUB local file header is malformed.');
+  }
+
+  const flags = readUint16(head, 6);
+  const compressionMethod = readUint16(head, 8);
+  const nameLength = readUint16(head, 26);
+  const extraLength = readUint16(head, 28);
+  const dataOffset = 30 + nameLength + extraLength;
+  if (flags !== 0 || compressionMethod !== 0 || nameLength !== 8 || extraLength !== 0) {
+    throw new EpubValidationError('The EPUB mimetype local header is malformed.');
+  }
+  if (dataOffset + 20 > head.length) {
+    throw new EpubValidationError('The EPUB mimetype entry is truncated.');
+  }
+  const localName = decodeName(head.subarray(30, dataOffset - extraLength), false);
+  if (localName !== 'mimetype') {
+    throw new EpubValidationError('The EPUB mimetype local header is malformed.');
+  }
+  const mimetype = new TextDecoder().decode(head.subarray(dataOffset, dataOffset + 20));
+  if (mimetype !== 'application/epub+zip') {
+    throw new EpubValidationError('The downloaded file is not an EPUB container.');
+  }
+}
+
+function validateContainerXml(bytes: Uint8Array): void {
+  let xml: string;
+  try {
+    xml = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  } catch {
+    throw new EpubValidationError('The EPUB container.xml encoding is invalid.');
+  }
+  if (typeof DOMParser === 'undefined') {
+    if (!/<container(?:\s|>)/i.test(xml) || !/<rootfile\b[^>]*\bfull-path\s*=/i.test(xml)) {
+      throw new EpubValidationError('The EPUB container.xml document is malformed.');
+    }
+    return;
+  }
+  const document = new DOMParser().parseFromString(xml, 'application/xml');
+  if (document.querySelector('parsererror') || document.documentElement.localName !== 'container') {
+    throw new EpubValidationError('The EPUB container.xml document is malformed.');
+  }
+  const rootFile = Array.from(document.getElementsByTagName('*')).find(
+    (element) => element.localName === 'rootfile',
+  );
+  if (!rootFile?.getAttribute('full-path')) {
+    throw new EpubValidationError('The EPUB container.xml document is missing its rootfile.');
+  }
+}
+
+async function readBoundedStream(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const result = await reader.read();
+      if (result.done) break;
+      total += result.value.byteLength;
+      if (total > MAX_CONTAINER_XML_SIZE) {
+        throw new EpubValidationError('The EPUB container entry is too large.');
+      }
+      chunks.push(result.value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
+async function validateContainerEntry(
+  entry: EpubArchiveEntry,
+  archiveOffset: number,
+  fileSize: number,
+  readRange: EpubRangeReader,
+): Promise<void> {
+  const localHeader = await readRange(entry.localHeaderOffset, 30);
+  requireRange(localHeader, 30, 'The EPUB container local header is truncated.');
+  if (!hasSignature(localHeader, 0, ZIP_LOCAL_FILE_HEADER)) {
+    throw new EpubValidationError('The EPUB container local header is malformed.');
+  }
+  const localFlags = readUint16(localHeader, 6);
+  const localMethod = readUint16(localHeader, 8);
+  const nameLength = readUint16(localHeader, 26);
+  const extraLength = readUint16(localHeader, 28);
+  const dataOffset = entry.localHeaderOffset + 30 + nameLength + extraLength;
+  if (
+    localMethod !== entry.compressionMethod ||
+    dataOffset < entry.localHeaderOffset ||
+    dataOffset + entry.compressedSize > archiveOffset ||
+    dataOffset + entry.compressedSize > fileSize
+  ) {
+    throw new EpubValidationError('The EPUB container entry is truncated.');
+  }
+  if (localFlags & 0x1 || localFlags & 0x40) {
+    throw new EpubValidationError('The EPUB container entry is encrypted.');
+  }
+
+  // Container XML is deliberately bounded to one MiB above. Reading just this
+  // entry lets us catch malformed stored XML while leaving large illustrated
+  // assets out of JavaScript memory.
+  const compressed = await readRange(dataOffset, entry.compressedSize);
+  requireRange(compressed, entry.compressedSize, 'The EPUB container entry is truncated.');
+  let uncompressed = compressed;
+  if (entry.compressionMethod === 8 && typeof DecompressionStream !== 'undefined') {
+    try {
+      const stream = new Blob([new Uint8Array(compressed).buffer as ArrayBuffer])
+        .stream()
+        .pipeThrough(new DecompressionStream('deflate-raw'));
+      const body = new Response(stream).body;
+      if (!body) throw new EpubValidationError('The EPUB container entry is malformed.');
+      uncompressed = await readBoundedStream(body);
+    } catch {
+      throw new EpubValidationError('The EPUB container entry is malformed.');
+    }
+  } else if (entry.compressionMethod === 8) {
+    // Older WebViews may not expose DecompressionStream. The central directory
+    // and bounds checks still protect the file, and EPUB.js will inflate it on
+    // open; do not reject otherwise valid illustrated EPUBs solely for that API.
+    return;
+  }
+  if (
+    uncompressed.length !== entry.uncompressedSize ||
+    uncompressed.length > MAX_CONTAINER_XML_SIZE
+  ) {
+    throw new EpubValidationError('The EPUB container entry is malformed.');
+  }
+  validateContainerXml(uncompressed);
+}
+
+/**
+ * Inspect only the ZIP header, end record, and central directory. The caller
+ * supplies a range reader so native files are never loaded wholesale merely
+ * to decide whether they are safe to mark as available.
+ */
+export async function validateEpubArchive(
+  fileSize: number,
+  readRange: EpubRangeReader,
+): Promise<void> {
+  if (!Number.isSafeInteger(fileSize) || fileSize < ZIP_END_OF_CENTRAL_DIRECTORY_LENGTH) {
+    throw new EpubValidationError('The downloaded EPUB is empty or too small.');
+  }
+  if (fileSize > MAX_EPUB_FILE_SIZE) {
+    throw new EpubValidationError('The downloaded EPUB is too large.');
+  }
+
+  const headLength = Math.min(fileSize, INITIAL_READ_SIZE);
+  const head = await readRange(0, headLength);
+  requireRange(head, headLength, 'The downloaded EPUB is truncated.');
+  const tailLength = Math.min(fileSize, ZIP_TAIL_READ_SIZE);
+  const tailOffset = fileSize - tailLength;
+  const tail = await readRange(tailOffset, tailLength);
+  requireRange(tail, tailLength, 'The EPUB ZIP end record is truncated.');
+
+  let endOffset = -1;
+  for (let offset = tail.length - ZIP_END_OF_CENTRAL_DIRECTORY_LENGTH; offset >= 0; offset -= 1) {
+    if (!hasSignature(tail, offset, ZIP_END_OF_CENTRAL_DIRECTORY)) continue;
+    const commentLength = readUint16(tail, offset + 20);
+    if (offset + ZIP_END_OF_CENTRAL_DIRECTORY_LENGTH + commentLength === tail.length) {
+      endOffset = offset;
+      break;
+    }
+  }
+  if (endOffset < 0) throw new EpubValidationError('The EPUB ZIP end record is missing.');
+
+  const entriesOnDisk = readUint16(tail, endOffset + 8);
+  const entries = readUint16(tail, endOffset + 10);
+  const centralDirectorySize = readUint32(tail, endOffset + 12);
+  const centralDirectoryOffset = readUint32(tail, endOffset + 16);
+  const diskNumber = readUint16(tail, endOffset + 4);
+  const centralDirectoryDisk = readUint16(tail, endOffset + 6);
+  if (
+    diskNumber !== 0 ||
+    centralDirectoryDisk !== 0 ||
+    entriesOnDisk !== entries ||
+    entries === 0 ||
+    entries > MAX_EPUB_ENTRIES ||
+    entries === 0xffff ||
+    centralDirectorySize > MAX_EPUB_CENTRAL_DIRECTORY_SIZE ||
+    centralDirectorySize < entries * 46 ||
+    centralDirectoryOffset + centralDirectorySize !== tailOffset + endOffset
+  ) {
+    throw new EpubValidationError('The EPUB ZIP central directory is invalid.');
+  }
+
+  const centralDirectory = await readRange(centralDirectoryOffset, centralDirectorySize);
+  requireRange(centralDirectory, centralDirectorySize, 'The EPUB central directory is truncated.');
+  const archiveEntries = parseCentralDirectory(centralDirectory, entries, centralDirectoryOffset);
+  const totalExpandedSize = archiveEntries.reduce(
+    (total, entry) => total + entry.uncompressedSize,
+    0,
+  );
+  if (totalExpandedSize > MAX_EPUB_EXPANDED_SIZE) {
+    throw new EpubValidationError('The EPUB expands beyond the supported size.');
+  }
+
+  const mimetype = archiveEntries[0];
+  const container = archiveEntries.find((entry) => entry.name === 'META-INF/container.xml');
+  if (!mimetype || !container) {
+    throw new EpubValidationError('The EPUB is missing its required container files.');
+  }
+  if (
+    container.name.endsWith('/') ||
+    container.uncompressedSize === 0 ||
+    container.uncompressedSize > MAX_CONTAINER_XML_SIZE
+  ) {
+    throw new EpubValidationError('The EPUB container.xml entry is invalid.');
+  }
+  validateMimetypeEntry(head, mimetype);
+  await validateContainerEntry(container, centralDirectoryOffset, fileSize, readRange);
+}

--- a/src/lib/downloads/native-download.test.ts
+++ b/src/lib/downloads/native-download.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const native = vi.hoisted(() => ({
+  body: new Uint8Array(),
+  deleted: [] as string[],
+  renamed: false,
+}));
+
+vi.mock('@capacitor/core', () => ({
+  Capacitor: {
+    isNativePlatform: () => true,
+    convertFileSrc: (value: string) => `web://${value}`,
+  },
+}));
+
+vi.mock('@capacitor/file-transfer', () => ({
+  FileTransfer: {
+    downloadFile: vi.fn(),
+  },
+}));
+
+vi.mock('@capacitor/filesystem', () => ({
+  Directory: { Data: 'DATA' },
+  Filesystem: {
+    stat: vi.fn(),
+    mkdir: vi.fn(),
+    getUri: vi.fn(),
+    readFile: vi.fn(),
+    rename: vi.fn(),
+    deleteFile: vi.fn(),
+  },
+}));
+
+import { FileTransfer } from '@capacitor/file-transfer';
+import { Filesystem } from '@capacitor/filesystem';
+import { downloadEpub, verifyDownloadedEpub } from './native-download';
+
+function encoded(bytes: Uint8Array): string {
+  return btoa(String.fromCharCode(...bytes));
+}
+
+beforeEach(() => {
+  native.body = new TextEncoder().encode(`<html>${'server error '.repeat(20)}</html>`);
+  native.deleted = [];
+  native.renamed = false;
+  vi.mocked(FileTransfer.downloadFile)
+    .mockReset()
+    .mockResolvedValue({} as never);
+  vi.mocked(Filesystem.mkdir).mockReset().mockResolvedValue(undefined);
+  vi.mocked(Filesystem.rename)
+    .mockReset()
+    .mockImplementation(async () => {
+      native.renamed = true;
+    });
+  vi.mocked(Filesystem.deleteFile)
+    .mockReset()
+    .mockImplementation(async ({ path }) => {
+      native.deleted.push(path);
+    });
+  vi.mocked(Filesystem.getUri)
+    .mockReset()
+    .mockImplementation(async ({ path }) => ({
+      uri: `file://${path}`,
+    }));
+  vi.mocked(Filesystem.stat)
+    .mockReset()
+    .mockImplementation(async ({ path }) => {
+      if (path === 'books') throw new Error('missing directory');
+      return {
+        type: 'file',
+        size: native.body.length,
+        name: path,
+        mtime: 0,
+        uri: `file://${path}`,
+      };
+    });
+  vi.mocked(Filesystem.readFile)
+    .mockReset()
+    .mockImplementation(async ({ offset = 0, length = -1 }) => ({
+      data: encoded(native.body.slice(offset, length > 0 ? offset + length : undefined)),
+    }));
+});
+
+describe('native EPUB download boundary', () => {
+  it('removes an HTML/error body from the partial path before rename', async () => {
+    await expect(
+      downloadEpub('https://books.example.com/download', 'secret', 'server-book'),
+    ).rejects.toThrow(/EPUB|ZIP|container/i);
+
+    expect(native.renamed).toBe(false);
+    expect(native.deleted).toContain('books/server-book.epub.partial');
+  });
+
+  it('does not inspect or delete a path outside the private books directory', async () => {
+    await expect(verifyDownloadedEpub('../outside.epub')).resolves.toBeNull();
+    expect(Filesystem.stat).not.toHaveBeenCalled();
+    expect(Filesystem.deleteFile).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/downloads/native-download.ts
+++ b/src/lib/downloads/native-download.ts
@@ -1,8 +1,43 @@
 import { Capacitor } from '@capacitor/core';
 import { FileTransfer } from '@capacitor/file-transfer';
 import { Directory, Filesystem } from '@capacitor/filesystem';
+import { validateEpubArchive } from './epub-validation';
 
 const BOOK_DIRECTORY = 'books';
+
+function decodeNativeBytes(data: string | Blob): Uint8Array {
+  if (typeof data !== 'string') throw new Error('The native EPUB could not be inspected.');
+  const binary = atob(data);
+  return Uint8Array.from(binary, (character) => character.charCodeAt(0));
+}
+
+async function readNativeRange(path: string, offset: number, length: number): Promise<Uint8Array> {
+  const result = await Filesystem.readFile({
+    path,
+    directory: Directory.Data,
+    offset,
+    length,
+  });
+  return decodeNativeBytes(result.data);
+}
+
+function assertSafeBookId(bookId: string): void {
+  if (!bookId || bookId === '.' || bookId === '..' || /[\\/\0]/.test(bookId)) {
+    throw new Error('Invalid EPUB file name.');
+  }
+}
+
+function assertSafeBookPath(path: string): void {
+  const segments = path.split('/');
+  if (
+    !path.startsWith(`${BOOK_DIRECTORY}/`) ||
+    segments.some((segment) => !segment || segment === '.' || segment === '..') ||
+    path.includes('\\') ||
+    segments.at(-1)?.toLowerCase().endsWith('.epub') !== true
+  ) {
+    throw new Error('Invalid downloaded EPUB path.');
+  }
+}
 
 export interface DownloadedBookFile {
   relativePath: string;
@@ -24,11 +59,13 @@ export async function downloadEpub(
 ): Promise<DownloadedBookFile> {
   if (!Capacitor.isNativePlatform()) throw new Error('Downloads require the native application.');
   if (!/^https?:\/\//i.test(downloadUrl)) throw new Error('Invalid Kavita download address.');
+  assertSafeBookId(bookId);
 
   await ensureDataDirectory(BOOK_DIRECTORY);
   const finalPath = `${BOOK_DIRECTORY}/${bookId}.epub`;
   const temporaryPath = `${finalPath}.partial`;
   const destination = await Filesystem.getUri({ path: temporaryPath, directory: Directory.Data });
+  let renamed = false;
 
   try {
     await FileTransfer.downloadFile({
@@ -38,13 +75,16 @@ export async function downloadEpub(
       progress: true,
     });
     const stat = await Filesystem.stat({ path: temporaryPath, directory: Directory.Data });
-    if (stat.type !== 'file' || stat.size < 22)
-      throw new Error('Kavita returned an empty EPUB file.');
+    if (stat.type !== 'file') throw new Error('Kavita did not return an EPUB file.');
+    await validateEpubArchive(stat.size, (offset, length) =>
+      readNativeRange(temporaryPath, offset, length),
+    );
     await Filesystem.rename({
       from: temporaryPath,
       to: finalPath,
       directory: Directory.Data,
     });
+    renamed = true;
     const final = await Filesystem.getUri({ path: finalPath, directory: Directory.Data });
     return {
       relativePath: finalPath,
@@ -54,6 +94,8 @@ export async function downloadEpub(
     };
   } catch (error) {
     await Filesystem.deleteFile({ path: temporaryPath, directory: Directory.Data }).catch(() => {});
+    if (renamed)
+      await Filesystem.deleteFile({ path: finalPath, directory: Directory.Data }).catch(() => {});
     throw error;
   }
 }
@@ -62,8 +104,16 @@ export async function verifyDownloadedEpub(
   relativePath: string,
 ): Promise<DownloadedBookFile | null> {
   try {
+    assertSafeBookPath(relativePath);
+  } catch {
+    return null;
+  }
+  try {
     const stat = await Filesystem.stat({ path: relativePath, directory: Directory.Data });
-    if (stat.type !== 'file' || stat.size < 22) return null;
+    if (stat.type !== 'file') return null;
+    await validateEpubArchive(stat.size, (offset, length) =>
+      readNativeRange(relativePath, offset, length),
+    );
     const uri = await Filesystem.getUri({ path: relativePath, directory: Directory.Data });
     return {
       relativePath,
@@ -72,12 +122,14 @@ export async function verifyDownloadedEpub(
       size: stat.size,
     };
   } catch {
+    await Filesystem.deleteFile({ path: relativePath, directory: Directory.Data }).catch(() => {});
     return null;
   }
 }
 
 export async function deleteDownloadedEpub(relativePath: string): Promise<void> {
   if (!Capacitor.isNativePlatform()) return;
+  assertSafeBookPath(relativePath);
   await Filesystem.deleteFile({ path: relativePath, directory: Directory.Data });
 }
 

--- a/src/lib/kavita/client.test.ts
+++ b/src/lib/kavita/client.test.ts
@@ -91,7 +91,7 @@ it('loads every series page for large libraries', async () => {
       ok: true,
       status: 200,
       headers: { get: () => null },
-      json: async () => [page[0]],
+      json: async () => [{ ...page[0], id: 500, name: 'Book 500' }],
     });
   vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
 
@@ -103,6 +103,56 @@ it('loads every series page for large libraries', async () => {
     'https://books.example.com/api/Series/v2?PageNumber=2&PageSize=500',
     expect.objectContaining({ method: 'POST' }),
   );
+});
+
+it('rejects malformed series payloads at the response boundary', async () => {
+  vi.mocked(fetch).mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    headers: { get: () => null },
+    json: async () => ({ unexpected: true }),
+  } as unknown as Response);
+
+  await expect(
+    new KavitaClient('https://books.example.com', 'abc123').getBookSeries(),
+  ).rejects.toMatchObject({
+    kind: 'invalid-response',
+  });
+});
+
+it('rejects a repeated series across pagination pages', async () => {
+  const page = Array.from({ length: 500 }, (_, id) => ({
+    id,
+    name: `Book ${id}`,
+    libraryId: 1,
+    format: 3,
+    pages: 1,
+    pagesRead: 0,
+    created: '2026-01-01',
+    latestReadDate: '0001-01-01T00:00:00',
+    coverImage: '',
+  }));
+  const fetchMock = vi
+    .fn()
+    .mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      json: async () => page,
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      json: async () => [page[0]],
+    });
+  vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
+
+  await expect(
+    new KavitaClient('https://books.example.com', 'abc123').getBookSeries(),
+  ).rejects.toMatchObject({
+    kind: 'invalid-response',
+  });
 });
 
 it.each([[[2, 4]], [[4]]])(
@@ -133,6 +183,51 @@ it.each([[[2, 4]], [[4]]])(
   },
 );
 
+it('rejects malformed library elements without inventing a server connection', async () => {
+  vi.mocked(fetch).mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    headers: { get: () => null },
+    json: async () => [{ id: 1, name: 'Books', type: '2' }],
+  } as unknown as Response);
+
+  await expect(
+    new KavitaClient('https://books.example.com', 'abc123').testConnection(),
+  ).rejects.toMatchObject({
+    kind: 'invalid-response',
+  });
+});
+
+it('rejects malformed series details before callers map them', async () => {
+  vi.mocked(fetch).mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    headers: { get: () => null },
+    json: async () => ({ chapters: [] }),
+  } as unknown as Response);
+
+  await expect(
+    new KavitaClient('https://books.example.com', 'abc123').getSeriesDetail(4),
+  ).rejects.toMatchObject({ kind: 'invalid-response' });
+});
+
+it('classifies malformed JSON as an invalid response', async () => {
+  vi.mocked(fetch).mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    headers: { get: () => null },
+    json: async () => {
+      throw new SyntaxError('Unexpected token');
+    },
+  } as unknown as Response);
+
+  await expect(
+    new KavitaClient('https://books.example.com', 'abc123').getBookSeries(),
+  ).rejects.toMatchObject({
+    kind: 'invalid-response',
+  });
+});
+
 it('retries a failed progress read once', async () => {
   const fetchMock = vi
     .fn()
@@ -145,7 +240,13 @@ it('retries a failed progress read once', async () => {
       ok: true,
       status: 200,
       headers: { get: () => null },
-      json: async () => ({ chapterId: 7, pageNum: 9 }),
+      json: async () => ({
+        libraryId: 1,
+        seriesId: 2,
+        volumeId: 3,
+        chapterId: 7,
+        pageNum: 9,
+      }),
     });
   vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
 

--- a/src/lib/kavita/client.ts
+++ b/src/lib/kavita/client.ts
@@ -6,12 +6,21 @@ import type {
   KavitaSeries,
   KavitaSeriesDetail,
 } from './types';
+import {
+  isKavitaLibrary,
+  isKavitaProgress,
+  isKavitaSeries,
+  isKavitaSeriesDetail,
+  readHealthVersion,
+} from './validation';
 
 const REQUEST_TIMEOUT_MS = 12_000;
 const BOOK_LIBRARY_TYPE = 2;
 const LIGHT_NOVEL_LIBRARY_TYPE = 4;
 const BROWSER_PROXY_PREFIX = '/__kavita__/';
 const SERIES_PAGE_SIZE = 500;
+const MAX_SERIES_RESULTS = 100_000;
+const MAX_SERIES_PAGES = MAX_SERIES_RESULTS / SERIES_PAGE_SIZE + 1;
 
 export class KavitaError extends Error {
   constructor(
@@ -31,16 +40,15 @@ export class KavitaClient {
 
   async testConnection(signal?: AbortSignal): Promise<ConnectedServer> {
     const options = signal ? { signal } : {};
-    const libraries = await this.request<KavitaLibrary[]>('/api/Library/libraries', options);
-    if (!Array.isArray(libraries)) {
+    const payload = await this.request<unknown>('/api/Library/libraries', options);
+    if (!Array.isArray(payload) || !payload.every(isKavitaLibrary)) {
       throw new KavitaError('Kavita returned an unexpected library response.', 'invalid-response');
     }
+    const libraries = payload as KavitaLibrary[];
 
-    const health = await this.request<{ version?: string }>('/api/Health', options).catch(
-      () => null,
-    );
+    const health = await this.request<unknown>('/api/Health', options).catch(() => null);
     return {
-      version: health?.version ?? null,
+      version: readHealthVersion(health),
       bookLibraries: libraries.filter(
         (library) =>
           library.type === BOOK_LIBRARY_TYPE || library.type === LIGHT_NOVEL_LIBRARY_TYPE,
@@ -50,7 +58,8 @@ export class KavitaClient {
 
   async getBookSeries(signal?: AbortSignal): Promise<KavitaSeries[]> {
     const series: KavitaSeries[] = [];
-    for (let pageNumber = 1; ; pageNumber += 1) {
+    const seenSeriesIds = new Set<number>();
+    for (let pageNumber = 1; pageNumber <= MAX_SERIES_PAGES; pageNumber += 1) {
       const options: RequestInit = {
         method: 'POST',
         body: JSON.stringify({
@@ -61,18 +70,44 @@ export class KavitaClient {
         }),
       };
       if (signal) options.signal = signal;
-      const page = await this.request<KavitaSeries[]>(
+      const payload = await this.request<unknown>(
         `/api/Series/v2?PageNumber=${pageNumber}&PageSize=${SERIES_PAGE_SIZE}`,
         options,
       );
+      if (
+        !Array.isArray(payload) ||
+        payload.length > SERIES_PAGE_SIZE ||
+        !payload.every(isKavitaSeries)
+      ) {
+        throw new KavitaError('Kavita returned an invalid series page.', 'invalid-response');
+      }
+      const page = payload as KavitaSeries[];
+      const pageIds = new Set<number>();
+      if (page.some((item) => pageIds.has(item.id) || seenSeriesIds.has(item.id))) {
+        throw new KavitaError('Kavita returned a repeated series page.', 'invalid-response');
+      }
+      page.forEach((item) => {
+        pageIds.add(item.id);
+        seenSeriesIds.add(item.id);
+      });
       series.push(...page);
+      if (series.length > MAX_SERIES_RESULTS) {
+        throw new KavitaError('Kavita returned too many series.', 'invalid-response');
+      }
       if (page.length < SERIES_PAGE_SIZE) break;
     }
     return series.filter((item) => item.format === 3);
   }
 
-  getSeriesDetail(seriesId: number, signal?: AbortSignal): Promise<KavitaSeriesDetail> {
-    return this.request(`/api/Series/series-detail?seriesId=${seriesId}`, signal ? { signal } : {});
+  async getSeriesDetail(seriesId: number, signal?: AbortSignal): Promise<KavitaSeriesDetail> {
+    const detail = await this.request<unknown>(
+      `/api/Series/series-detail?seriesId=${seriesId}`,
+      signal ? { signal } : {},
+    );
+    if (!isKavitaSeriesDetail(detail)) {
+      throw new KavitaError('Kavita returned an invalid series detail.', 'invalid-response');
+    }
+    return detail;
   }
 
   downloadUrl(chapterId: number): string {
@@ -96,8 +131,16 @@ export class KavitaClient {
       });
       this.assertStatus(response.status);
       if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
-      const encoded = String(response.data);
-      const binary = atob(encoded.includes(',') ? (encoded.split(',').pop() ?? '') : encoded);
+      if (typeof response.data !== 'string') {
+        throw new KavitaError('Kavita returned an invalid cover response.', 'invalid-response');
+      }
+      const encoded = response.data;
+      let binary: string;
+      try {
+        binary = atob(encoded.includes(',') ? (encoded.split(',').pop() ?? '') : encoded);
+      } catch {
+        throw new KavitaError('Kavita returned an invalid cover response.', 'invalid-response');
+      }
       const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
       const blob = new Blob([bytes]);
       if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
@@ -122,10 +165,24 @@ export class KavitaClient {
     const path = `/api/Reader/get-progress?chapterId=${chapterId}`;
     const options = signal ? { signal } : {};
     try {
-      return await this.request(path, options);
+      const progress = await this.request<unknown>(path, options);
+      if (!isKavitaProgress(progress)) {
+        throw new KavitaError(
+          'Kavita returned an invalid reading progress response.',
+          'invalid-response',
+        );
+      }
+      return progress;
     } catch (error) {
       if (signal?.aborted) throw error;
-      return this.request(path, options);
+      const progress = await this.request<unknown>(path, options);
+      if (!isKavitaProgress(progress)) {
+        throw new KavitaError(
+          'Kavita returned an invalid reading progress response.',
+          'invalid-response',
+        );
+      }
+      return progress;
     }
   }
 
@@ -169,7 +226,11 @@ export class KavitaClient {
       if (response.status === 204 || response.headers.get('content-length') === '0') {
         return undefined as T;
       }
-      return (await response.json()) as T;
+      try {
+        return (await response.json()) as T;
+      } catch {
+        throw new KavitaError('Kavita returned malformed JSON.', 'invalid-response');
+      }
     } catch (error) {
       if (error instanceof KavitaError) throw error;
       const message = timeout.signal.aborted
@@ -202,7 +263,11 @@ export class KavitaClient {
       if (init.signal?.aborted) throw new DOMException('Aborted', 'AbortError');
       if (typeof response.data === 'string') {
         if (!response.data.trim()) return undefined as T;
-        return JSON.parse(response.data) as T;
+        try {
+          return JSON.parse(response.data) as T;
+        } catch {
+          throw new KavitaError('Kavita returned malformed JSON.', 'invalid-response');
+        }
       }
       return response.data as T;
     } catch (error) {

--- a/src/lib/kavita/validation.ts
+++ b/src/lib/kavita/validation.ts
@@ -1,0 +1,126 @@
+import type {
+  KavitaChapter,
+  KavitaLibrary,
+  KavitaProgress,
+  KavitaSeries,
+  KavitaSeriesDetail,
+  KavitaVolume,
+  KavitaFile,
+  KavitaPerson,
+} from './types';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isInteger(value: unknown, minimum = 0): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= minimum;
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}
+
+export function isKavitaLibrary(value: unknown): value is KavitaLibrary {
+  return (
+    isRecord(value) &&
+    isInteger(value.id) &&
+    (value.name === null || isString(value.name)) &&
+    isInteger(value.type)
+  );
+}
+
+export function isKavitaSeries(value: unknown): value is KavitaSeries {
+  return (
+    isRecord(value) &&
+    isInteger(value.id) &&
+    isString(value.name) &&
+    isInteger(value.libraryId) &&
+    isInteger(value.format) &&
+    isInteger(value.pages) &&
+    isInteger(value.pagesRead) &&
+    isString(value.created) &&
+    isString(value.latestReadDate) &&
+    isString(value.coverImage)
+  );
+}
+
+export function isKavitaFile(value: unknown): value is KavitaFile {
+  return (
+    isRecord(value) &&
+    isInteger(value.id) &&
+    isInteger(value.bytes) &&
+    isString(value.extension) &&
+    isInteger(value.format)
+  );
+}
+
+export function isKavitaPerson(value: unknown): value is KavitaPerson {
+  return isRecord(value) && isString(value.name);
+}
+
+export function isKavitaChapter(value: unknown): value is KavitaChapter {
+  return (
+    isRecord(value) &&
+    isInteger(value.id) &&
+    isString(value.title) &&
+    isString(value.titleName) &&
+    isInteger(value.volumeId) &&
+    isInteger(value.pages) &&
+    (value.pagesRead === undefined || isInteger(value.pagesRead)) &&
+    isString(value.summary) &&
+    isInteger(value.format) &&
+    Array.isArray(value.files) &&
+    value.files.every(isKavitaFile) &&
+    Array.isArray(value.writers) &&
+    value.writers.every(isKavitaPerson) &&
+    (value.lastReadingProgressUtc === undefined ||
+      value.lastReadingProgressUtc === null ||
+      isString(value.lastReadingProgressUtc))
+  );
+}
+
+export function isKavitaVolume(value: unknown): value is KavitaVolume {
+  return (
+    isRecord(value) &&
+    isInteger(value.id) &&
+    Array.isArray(value.chapters) &&
+    value.chapters.every(isKavitaChapter)
+  );
+}
+
+export function isKavitaSeriesDetail(value: unknown): value is KavitaSeriesDetail {
+  return (
+    isRecord(value) &&
+    Array.isArray(value.chapters) &&
+    value.chapters.every(isKavitaChapter) &&
+    Array.isArray(value.specials) &&
+    value.specials.every(isKavitaChapter) &&
+    Array.isArray(value.storylineChapters) &&
+    value.storylineChapters.every(isKavitaChapter) &&
+    (value.volumes === undefined ||
+      (Array.isArray(value.volumes) && value.volumes.every(isKavitaVolume)))
+  );
+}
+
+export function isKavitaProgress(value: unknown): value is KavitaProgress {
+  return (
+    isRecord(value) &&
+    isInteger(value.libraryId) &&
+    isInteger(value.seriesId) &&
+    isInteger(value.volumeId) &&
+    isInteger(value.chapterId) &&
+    isInteger(value.pageNum) &&
+    (value.bookScrollId === undefined ||
+      value.bookScrollId === null ||
+      isString(value.bookScrollId)) &&
+    (value.lastModifiedUtc === undefined || isString(value.lastModifiedUtc))
+  );
+}
+
+export function readHealthVersion(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  if (!isRecord(value)) return null;
+  if (value.version === undefined || value.version === null) return null;
+  return isString(value.version) ? value.version : null;
+}


### PR DESCRIPTION
## Summary

- Inspect downloaded EPUBs through bounded native file ranges before rename/availability.
- Require the EPUB mimetype/container entries and reject HTML/error bodies, truncated or malformed ZIPs, unsafe paths, excessive entries, and oversized expanded content.
- Validate Kavita library, series pagination, series detail, progress, cover, and JSON payload shapes; repeated or malformed pages fail the refresh before local replacement.
- Add focused EPUB/download/client tests and update `RELEASE_NOTES.md`.

## Validation

- `npm run check`
- `npm test` (109 tests)
- `npm run lint`
- `npm run format:check`

The implementation is limited to S3 download and server-payload trust boundaries; cover-loading behavior is unchanged.
