### PR TITLE
perf: prioritize and share cover loads

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - docs: add future implementation work plan
+- Prioritize visible covers and share bounded requests across refresh generations, with server-scoped native cache files and safe partial transfers.
 - Add accessible modal semantics, focus trapping, Escape/backdrop closing, and focus restoration to library and reader panels.
 - Add keyboard page navigation and an accessible reader shortcut hint for non-touch users.
 - Increase compact library controls to touch-friendly targets and expose reading progress to assistive technology.

--- a/src/lib/components/Library.svelte
+++ b/src/lib/components/Library.svelte
@@ -3,6 +3,7 @@
   import { Capacitor } from '@capacitor/core';
   import { Network } from '@capacitor/network';
   import { tick, onDestroy, onMount } from 'svelte';
+  import { SvelteSet } from 'svelte/reactivity';
   import { fade, fly } from 'svelte/transition';
   import {
     getBooks,
@@ -26,7 +27,11 @@
     downloadEpub,
     verifyDownloadedEpub,
   } from '../downloads/native-download';
-  import { loadCoversWithConcurrency } from '../downloads/cover-loader';
+  import {
+    createSharedCoverLoader,
+    loadCoversWithConcurrency,
+    type CoverLoadItem,
+  } from '../downloads/cover-loader';
   import { KavitaClient } from '../kavita/client';
   import { mapSeriesToBooks } from '../kavita/mapper';
   import type { KavitaProgress } from '../kavita/types';
@@ -201,6 +206,14 @@
     onServerDeleted: () => void;
   } = $props();
   const client = $derived(new KavitaClient(server.baseUrl, apiKey));
+  const sharedCoverLoader = createSharedCoverLoader<string>(async (seriesId, signal) => {
+    if (Capacitor.isNativePlatform()) {
+      return cacheCover(client.coverUrl(seriesId), apiKey, seriesId, signal, server.id);
+    }
+    const blob = await client.getCover(seriesId, signal);
+    if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
+    return URL.createObjectURL(blob);
+  });
   let books = $state<BookRecord[]>([]);
   let query = $state('');
   let downloadedOnly = $state(false);
@@ -271,7 +284,6 @@
   let virtualizationFrame: number | null = null;
   let syncTimer: number | null = null;
   const cleanups: Array<() => Promise<void>> = [];
-  const nativePlatform = Capacitor.isNativePlatform();
   const SERIES_DETAIL_BATCH_SIZE = 8;
   const VIRTUALIZATION_OVERSCAN_ROWS = 2;
   const GRID_GAP_PX = 16;
@@ -471,6 +483,7 @@
     window.removeEventListener('resize', scheduleVirtualWindow);
     cancelCoverLoading();
     clearCovers();
+    sharedCoverLoader.cancel();
     cleanups.forEach((remove) => void remove());
   });
 
@@ -544,19 +557,29 @@
     const controller = new AbortController();
     const generation = coverLoadGeneration;
     coverLoadController = controller;
+    const priority: BookRecord[] = [];
+    if (continueBook) priority.push(continueBook);
+    const firstVisibleIndex =
+      virtualWindow.endIndex > virtualWindow.startIndex ? virtualWindow.startIndex : 0;
+    const visibleEndIndex =
+      virtualWindow.endIndex > virtualWindow.startIndex
+        ? virtualWindow.endIndex
+        : Math.min(visibleBooks.length, gridColumns * 3);
+    priority.push(...visibleBooks.slice(firstVisibleIndex, visibleEndIndex));
+    const ordered = [...priority, ...items];
+    const prioritizedItems: CoverLoadItem[] = [];
+    const seenSeries = new SvelteSet<number>();
+    for (const book of ordered) {
+      if (seenSeries.has(book.seriesId)) continue;
+      seenSeries.add(book.seriesId);
+      prioritizedItems.push({ seriesId: book.seriesId });
+    }
     try {
-      await loadCoversWithConcurrency(items, {
+      await loadCoversWithConcurrency(prioritizedItems, {
         signal: controller.signal,
         concurrency: COVER_LOAD_CONCURRENCY,
         hasCover: (seriesId) => Boolean(covers[seriesId]),
-        load: async (seriesId, signal) => {
-          if (nativePlatform) {
-            return cacheCover(client.coverUrl(seriesId), apiKey, seriesId, signal);
-          }
-          const blob = await client.getCover(seriesId, signal);
-          if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
-          return URL.createObjectURL(blob);
-        },
+        load: (seriesId) => sharedCoverLoader.load(seriesId),
         dispose: revokeBrowserCover,
         onLoaded: (seriesId, cover) => {
           if (destroyed || controller.signal.aborted || generation !== coverLoadGeneration) {
@@ -788,6 +811,8 @@
 
   async function clearCache(): Promise<void> {
     cancelCoverLoading();
+    await sharedCoverLoader.waitForIdle();
+    if (destroyed) return;
     await clearCoverCache();
     if (destroyed) return;
     clearCovers();

--- a/src/lib/downloads/cover-loader.test.ts
+++ b/src/lib/downloads/cover-loader.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { loadCoversWithConcurrency } from './cover-loader';
+import { createSharedCoverLoader, loadCoversWithConcurrency } from './cover-loader';
 
 describe('loadCoversWithConcurrency', () => {
   it('deduplicates series and limits active loads', async () => {
@@ -67,5 +67,62 @@ describe('loadCoversWithConcurrency', () => {
     });
 
     expect(requested).toEqual([2]);
+  });
+});
+
+describe('createSharedCoverLoader', () => {
+  it('shares a request and caps physical work across refresh generations', async () => {
+    const pending: Array<() => void> = [];
+    let active = 0;
+    let maximumActive = 0;
+    let calls = 0;
+    const shared = createSharedCoverLoader<number>(async (seriesId) => {
+      calls += 1;
+      active += 1;
+      maximumActive = Math.max(maximumActive, active);
+      await new Promise<void>((resolve) => pending.push(resolve));
+      active -= 1;
+      return seriesId;
+    }, 2);
+
+    const first = shared.load(1);
+    const replacement = shared.load(1);
+    const second = shared.load(2);
+    const queued = shared.load(3);
+
+    expect(replacement).toBe(first);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(calls).toBe(2);
+    expect(maximumActive).toBe(2);
+
+    pending.shift()?.();
+    pending.shift()?.();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(calls).toBe(3);
+    pending.shift()?.();
+
+    await expect(Promise.all([first, replacement, second, queued])).resolves.toEqual([1, 1, 2, 3]);
+    expect(maximumActive).toBe(2);
+  });
+
+  it('cancels active and queued requests', async () => {
+    let aborted = false;
+    const shared = createSharedCoverLoader<number>(async (_seriesId, signal) => {
+      await new Promise<void>((resolve) => {
+        signal.addEventListener('abort', () => {
+          aborted = true;
+          resolve();
+        });
+      });
+      throw new DOMException('Aborted', 'AbortError');
+    }, 1);
+    const active = shared.load(1);
+    const queued = shared.load(2);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    shared.cancel();
+
+    await expect(active).rejects.toMatchObject({ name: 'AbortError' });
+    await expect(queued).rejects.toMatchObject({ name: 'AbortError' });
+    expect(aborted).toBe(true);
   });
 });

--- a/src/lib/downloads/cover-loader.ts
+++ b/src/lib/downloads/cover-loader.ts
@@ -2,6 +2,12 @@ export interface CoverLoadItem {
   seriesId: number;
 }
 
+export interface SharedCoverLoader<T> {
+  load: (seriesId: number) => Promise<T>;
+  waitForIdle: () => Promise<void>;
+  cancel: () => void;
+}
+
 export interface CoverLoaderOptions<T> {
   signal: AbortSignal;
   concurrency?: number;
@@ -9,6 +15,84 @@ export interface CoverLoaderOptions<T> {
   load: (seriesId: number, signal: AbortSignal) => Promise<T>;
   onLoaded: (seriesId: number, cover: T) => void;
   dispose?: (cover: T) => void;
+}
+
+/**
+ * Share physical cover requests across refresh generations. A view can be
+ * cancelled and replaced while a native transfer is still running; keeping
+ * that transfer alive lets the replacement view consume its result instead of
+ * starting a second transfer for the same series.
+ */
+export function createSharedCoverLoader<T>(
+  load: (seriesId: number, signal: AbortSignal) => Promise<T>,
+  concurrency = 6,
+): SharedCoverLoader<T> {
+  type Request = {
+    controller: AbortController;
+    promise: Promise<T>;
+    resolve: (value: T | PromiseLike<T>) => void;
+    reject: (reason?: unknown) => void;
+  };
+  const requests = new Map<number, Request>();
+  const pending: Array<{ seriesId: number; request: Request }> = [];
+  const maxConcurrency = Math.max(1, Math.floor(Number.isFinite(concurrency) ? concurrency : 1));
+  let active = 0;
+
+  function finish(seriesId: number, request: Request): void {
+    if (requests.get(seriesId) === request) requests.delete(seriesId);
+    active = Math.max(0, active - 1);
+    pump();
+  }
+
+  function pump(): void {
+    while (active < maxConcurrency && pending.length > 0) {
+      const next = pending.shift();
+      if (!next) return;
+      const { seriesId, request } = next;
+      if (request.controller.signal.aborted) {
+        request.reject(new DOMException('Aborted', 'AbortError'));
+        if (requests.get(seriesId) === request) requests.delete(seriesId);
+        continue;
+      }
+      active += 1;
+      void Promise.resolve()
+        .then(() => {
+          if (request.controller.signal.aborted) throw new DOMException('Aborted', 'AbortError');
+          return load(seriesId, request.controller.signal);
+        })
+        .then(request.resolve, request.reject)
+        .finally(() => finish(seriesId, request));
+    }
+  }
+
+  return {
+    load(seriesId) {
+      const existing = requests.get(seriesId);
+      if (existing) return existing.promise;
+      const controller = new AbortController();
+      let resolve!: Request['resolve'];
+      let reject!: Request['reject'];
+      const promise = new Promise<T>((promiseResolve, promiseReject) => {
+        resolve = promiseResolve;
+        reject = promiseReject;
+      });
+      const request = { controller, promise, resolve, reject };
+      requests.set(seriesId, request);
+      pending.push({ seriesId, request });
+      pump();
+      return promise;
+    },
+    async waitForIdle() {
+      await Promise.allSettled([...requests.values()].map(({ promise }) => promise));
+    },
+    cancel() {
+      for (const { controller, reject } of requests.values()) {
+        controller.abort();
+        reject(new DOMException('Aborted', 'AbortError'));
+      }
+      pending.length = 0;
+    },
+  };
 }
 
 /**

--- a/src/lib/downloads/native-download.ts
+++ b/src/lib/downloads/native-download.ts
@@ -4,6 +4,11 @@ import { Directory, Filesystem } from '@capacitor/filesystem';
 
 const BOOK_DIRECTORY = 'books';
 
+function safeCoverNamespace(value: string): string {
+  const normalized = value.replace(/[^a-z0-9_-]+/gi, '_').replace(/^\.+|\.+$/g, '');
+  return normalized.slice(0, 80) || 'default';
+}
+
 export interface DownloadedBookFile {
   relativePath: string;
   nativeUri: string;
@@ -86,21 +91,42 @@ export async function cacheCover(
   apiKey: string,
   seriesId: number,
   signal?: AbortSignal,
+  cacheNamespace = 'default',
 ): Promise<string> {
   if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
   const directory = 'covers';
-  const path = `${directory}/${seriesId}.img`;
+  const namespace = safeCoverNamespace(cacheNamespace);
+  const path = `${directory}/${namespace}/${seriesId}.img`;
+  const temporaryPath = `${path}.partial`;
   await ensureDataDirectory(directory);
+  await ensureDataDirectory(`${directory}/${namespace}`);
   if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
   const existing = await Filesystem.getUri({ path, directory: Directory.Data });
   const valid = await Filesystem.stat({ path, directory: Directory.Data }).catch(() => null);
-  if (!valid || valid.size === 0) {
+  if (!valid || valid.type !== 'file' || valid.size === 0) {
     if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
-    await FileTransfer.downloadFile({
-      url: downloadUrl,
-      path: existing.uri,
-      headers: { 'x-api-key': apiKey },
-    });
+    await Filesystem.deleteFile({ path: temporaryPath, directory: Directory.Data }).catch(() => {});
+    const temporary = await Filesystem.getUri({ path: temporaryPath, directory: Directory.Data });
+    try {
+      await FileTransfer.downloadFile({
+        url: downloadUrl,
+        path: temporary.uri,
+        headers: { 'x-api-key': apiKey },
+      });
+      const downloaded = await Filesystem.stat({ path: temporaryPath, directory: Directory.Data });
+      if (downloaded.type !== 'file' || downloaded.size === 0)
+        throw new Error('Kavita returned an empty cover.');
+      await Filesystem.rename({
+        from: temporaryPath,
+        to: path,
+        directory: Directory.Data,
+      });
+    } catch (error) {
+      await Filesystem.deleteFile({ path: temporaryPath, directory: Directory.Data }).catch(
+        () => {},
+      );
+      throw error;
+    }
   }
   if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
   return Capacitor.convertFileSrc(existing.uri);


### PR DESCRIPTION
## Summary
- prioritize Continue Reading and visible/overscan covers before the rest of the library
- share in-flight cover requests across refresh generations behind a shared concurrency ceiling
- wait for active cover work before clearing the native cache
- scope native cover paths per server and use partial files before publishing a final cover

## Validation
- npm run check
- npm test -- --run
- npm run format:check
- npm run lint
