### PR TITLE
docs: add iOS readiness matrix

### DIFF
--- a/IOS_BUILD.md
+++ b/IOS_BUILD.md
@@ -2,6 +2,10 @@
 
 The iOS Capacitor project is scaffolded and synchronized. It was not compiled or simulator-tested on Linux.
 
+The iOS release status remains **unverified** until the checks below are completed on macOS and at
+least one real iPhone. Record the date, device/OS, app build, and result for each check before
+describing an iOS build as ready.
+
 ## macOS commands
 
 ```bash
@@ -30,3 +34,24 @@ In Xcode:
 5. Use Product > Archive for a distribution build, then validate signing in Organizer.
 
 Filesystem, File Transfer, SQLite, secure Keychain storage, app lifecycle, ATS behavior, and native EPUB file loading still require macOS/device verification. `NSAllowsArbitraryLoads` exists solely for user-approved HTTP Kavita servers; remove it if HTTP support is dropped or replace it with known-host exceptions for a managed deployment.
+
+## Readiness matrix
+
+Run the matrix on a simulator and a physical device where the check depends on hardware or
+platform services. Attach logs or screenshots to the release record rather than treating a
+successful Xcode compile as acceptance.
+
+| Area                     | Check                                                                                             | Evidence to record                                   |
+| ------------------------ | ------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| Build and signing        | Debug build, archive, bundle identifier, team, and privacy manifest                               | Xcode build/archive result and signing configuration |
+| Secure storage           | Save, replace, reject, and delete a Kavita key; relaunch the app                                  | Keychain behavior and error recovery                 |
+| SQLite                   | Fresh install, migration from each supported schema, interrupted migration, and reopen            | Migration log and retained local data                |
+| Downloads                | Start, cancel/interrupt, reopen offline, remove, and recover a partial EPUB                       | File manifest and offline open result                |
+| Lifecycle                | Background during refresh, download, reader progress, and sync; resume after termination          | Device log and restored state                        |
+| Reader                   | Safe EPUB rendering, CFI restoration, table of contents, links/footnotes, and appearance settings | Screen recording or test notes                       |
+| Accessibility            | VoiceOver navigation, focus order, Dynamic Type, contrast, and reduced motion                     | VoiceOver smoke-test notes and screenshots           |
+| Network policy           | HTTPS, approved HTTP warning, timeout, auth rejection, and ATS behavior                           | Request trace and visible recovery state             |
+| Device layout            | Portrait/landscape, safe areas, external keyboard, and rotation during the reader                 | Device matrix and screenshots                        |
+| Privacy and distribution | Backup behavior, app-private files, archive validation, and TestFlight installation               | Archive/export checklist and privacy review          |
+
+Release readiness requires every applicable row to pass or have a documented, accepted exception.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - docs: add future implementation work plan
+- Document the iOS readiness matrix and keep platform support explicitly unverified until macOS and device checks pass.
 - Add accessible modal semantics, focus trapping, Escape/backdrop closing, and focus restoration to library and reader panels.
 - Add keyboard page navigation and an accessible reader shortcut hint for non-touch users.
 - Increase compact library controls to touch-friendly targets and expose reading progress to assistive technology.


### PR DESCRIPTION
## Summary
- document iOS support as unverified until macOS and physical-device checks pass
- add a release readiness matrix covering build, storage, downloads, lifecycle, reader, accessibility, network, privacy, and device layout
- require evidence or an accepted exception for each applicable check

## Validation
- npm run format:check
- git diff --check
