### PR TITLE
test: add library performance baseline

### DIFF
--- a/PERFORMANCE_BASELINE.md
+++ b/PERFORMANCE_BASELINE.md
@@ -1,0 +1,19 @@
+# Performance baseline
+
+The repository includes a small deterministic benchmark for the library's
+virtualized window calculation. It exercises 500, 5,000, and 10,000-book
+datasets at several scroll positions without rendering a browser or contacting
+Kavita.
+
+Run it with:
+
+```bash
+npm ci
+npm run benchmark:library
+```
+
+Record the benchmark output with the commit, OS, CPU, Node version, and whether
+the run was warm or cold. Compare measurements on the same machine and dataset;
+Vitest's operations per second are useful for detecting regressions but are not
+a user-visible frame-rate guarantee. Use the browser/device acceptance matrix
+for scroll frame time, memory, bridge calls, and network measurements.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - docs: add future implementation work plan
+- Add a reproducible library virtualization benchmark for 500, 5,000, and 10,000-book datasets.
 - Add accessible modal semantics, focus trapping, Escape/backdrop closing, and focus restoration to library and reader panels.
 - Add keyboard page navigation and an accessible reader shortcut hint for non-touch users.
 - Increase compact library controls to touch-friendly targets and expose reading progress to assistive technology.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "format:check": "prettier --check .",
     "test": "vitest run",
     "test:watch": "vitest",
+    "benchmark:library": "vitest bench src/lib/components/library-virtualization.bench.ts",
     "build": "npm run check && vite build",
     "release:finalize": "node scripts/finalize-release-notes.mjs",
     "release:notes": "node scripts/release-notes.mjs",

--- a/src/lib/components/library-virtualization.bench.ts
+++ b/src/lib/components/library-virtualization.bench.ts
@@ -1,0 +1,15 @@
+import { bench, describe } from 'vitest';
+import { calculateVirtualWindow } from './library-virtualization';
+
+const datasetSizes = [500, 5_000, 10_000];
+const scrollPositions = [0, 1_234, 250_000, 1_000_000];
+
+describe('library virtualization baseline', () => {
+  for (const itemCount of datasetSizes) {
+    bench(`${itemCount.toLocaleString()} books`, () => {
+      for (const scrollTop of scrollPositions) {
+        calculateVirtualWindow(itemCount, 5, 420, scrollTop, 900, 2);
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add deterministic Vitest benchmarks for 500, 5,000, and 10,000-book virtualized windows
- document how to record repeatable measurements with hardware and runtime context

## Validation
- npm run benchmark:library
- npm run check
- npm test -- --run
- npm run format:check
- npm run lint
