### PR TITLE
feat: expose reading sync status

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - docs: add future implementation work plan
+- Show queued and failed reading-progress sync state with an explicit retry action.
 - Add accessible modal semantics, focus trapping, Escape/backdrop closing, and focus restoration to library and reader panels.
 - Add keyboard page navigation and an accessible reader shortcut hint for non-touch users.
 - Increase compact library controls to touch-friendly targets and expose reading progress to assistive technology.

--- a/src/lib/components/Library.svelte
+++ b/src/lib/components/Library.svelte
@@ -8,6 +8,7 @@
     getBooks,
     getReadingState,
     getPreference,
+    getSyncStatus,
     markDownloaded,
     markBookCompleted,
     removeDownload,
@@ -18,6 +19,7 @@
     setPreference,
     type BookRecord,
     type ServerConfig,
+    type SyncStatus,
   } from '../database/database';
   import {
     cacheCover,
@@ -246,6 +248,13 @@
   let downloadingBookId = $state<string | null>(null);
   let offline = $state(false);
   let message = $state('');
+  let syncStatus = $state<SyncStatus>({
+    pendingCount: 0,
+    failedCount: 0,
+    lastError: null,
+    lastUpdatedAt: null,
+  });
+  let syncing = $state(false);
   let settingsVisible = $state(false);
   let pendingTheme = $state<SkeletonTheme>('vintage');
   let pendingMode = $state<'light' | 'dark'>('dark');
@@ -414,6 +423,8 @@
     pendingAutoSync = savedAutoSync === null ? true : savedAutoSync === 'true';
     books = await getBooks(server.id);
     if (destroyed) return;
+    await refreshSyncStatus();
+    if (destroyed) return;
     retainCoversFor(books);
     void loadCovers(books);
     loading = false;
@@ -427,7 +438,7 @@
           if (destroyed) return;
           offline = !connected;
           if (connected)
-            void flushProgress(client)
+            void syncProgress(false)
               .then(refresh)
               .catch(() => {});
         }),
@@ -436,7 +447,7 @@
     cleanups.push(
       await registerListener(
         await App.addListener('appStateChange', ({ isActive }) => {
-          if (!destroyed && !isActive) void flushProgress(client).catch(() => {});
+          if (!destroyed && !isActive) void syncProgress(false);
         }),
       ),
     );
@@ -461,6 +472,34 @@
       return async () => {};
     }
     return handle.remove;
+  }
+
+  async function refreshSyncStatus(): Promise<void> {
+    try {
+      syncStatus = await getSyncStatus();
+    } catch {
+      // A status read must not block opening the saved library.
+    }
+  }
+
+  async function syncProgress(showFeedback = true): Promise<void> {
+    if (syncing) return;
+    syncing = true;
+    try {
+      if (offline) {
+        if (showFeedback)
+          message = 'Offline. Reading progress will retry when Kavita is available.';
+        return;
+      }
+      await flushProgress(client);
+      if (showFeedback) message = 'Reading progress synced.';
+    } catch {
+      if (showFeedback)
+        message = 'Some reading progress is waiting to sync. Try again when online.';
+    } finally {
+      await refreshSyncStatus();
+      syncing = false;
+    }
   }
 
   onDestroy(() => {
@@ -663,7 +702,7 @@
         xpath: null,
         percentage: null,
       };
-      if (preferFurthest) void flushProgress(client).catch(() => {});
+      if (preferFurthest) void syncProgress(false);
       return;
     }
     if (openProgress === 'conflict' && local && remote) {
@@ -703,8 +742,9 @@
       location.spineIndex,
     );
     books = await getBooks(server.id);
+    await refreshSyncStatus();
     if (syncTimer !== null) window.clearTimeout(syncTimer);
-    syncTimer = window.setTimeout(() => void flushProgress(client).catch(() => {}), 2_500);
+    syncTimer = window.setTimeout(() => void syncProgress(false), 2_500);
   }
 
   async function syncLatestForReader(
@@ -731,7 +771,7 @@
           }
         : item,
     );
-    void flushProgress(client).catch(() => {});
+    void syncProgress(false);
     message = `${book.title} marked as read.`;
     closeMenu();
   }
@@ -1069,6 +1109,31 @@
     {#if message}
       <div class="alert preset-tonal-surface mt-4" role="status" transition:fade>
         {message}
+      </div>
+    {/if}
+    {#if syncStatus.pendingCount > 0}
+      <div
+        class="alert preset-tonal-warning mt-4 flex flex-wrap items-center justify-between gap-3"
+        role="status"
+      >
+        <div class="min-w-0">
+          <p>
+            {syncStatus.failedCount > 0
+              ? `${syncStatus.failedCount} reading progress update${syncStatus.failedCount === 1 ? '' : 's'} failed and remain queued.`
+              : `${syncStatus.pendingCount} reading progress update${syncStatus.pendingCount === 1 ? '' : 's'} waiting to sync.`}
+          </p>
+          {#if syncStatus.lastError}
+            <p class="mt-1 truncate text-xs opacity-80">Last error: {syncStatus.lastError}</p>
+          {/if}
+        </div>
+        <button
+          class="btn btn-sm preset-tonal-warning h-10 shrink-0"
+          type="button"
+          onclick={() => void syncProgress()}
+          disabled={syncing || offline}
+        >
+          {syncing ? 'Retrying...' : 'Retry sync'}
+        </button>
       </div>
     {/if}
 

--- a/src/lib/database/database.test.ts
+++ b/src/lib/database/database.test.ts
@@ -1,6 +1,6 @@
 import { expect, it, vi } from 'vitest';
 import type { capSQLiteChanges, capTask } from '@capacitor-community/sqlite';
-import { confirmSync, replaceBooksInTransaction, type BookRecord } from './database';
+import { confirmSync, getSyncStatus, replaceBooksInTransaction, type BookRecord } from './database';
 
 const BROWSER_STORAGE_KEY = 'turnleaf_browser_database_v1';
 
@@ -211,4 +211,47 @@ it('does not acknowledge a queue item that was replaced while it uploaded', asyn
   await confirmSync('book-1', '2026-09-07T00:00:02.000Z', '2026-09-07T00:00:00.000Z');
 
   expect(JSON.parse(localStorage.getItem(BROWSER_STORAGE_KEY) ?? '{}')).toEqual(state);
+});
+
+it('reports pending and failed browser sync work for recovery UI', async () => {
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: new MemoryStorage(),
+  });
+  localStorage.setItem(
+    BROWSER_STORAGE_KEY,
+    JSON.stringify({
+      serverConfig: null,
+      books: [],
+      readingState: {},
+      syncQueue: {
+        'book-1': {
+          bookId: 'book-1',
+          payloadJson: '{}',
+          attemptCount: 1,
+          lastAttemptAt: '2026-09-07T00:00:01.000Z',
+          lastError: 'Kavita rejected this auth key.',
+          createdAt: '2026-09-07T00:00:00.000Z',
+          updatedAt: '2026-09-07T00:00:01.000Z',
+        },
+        'book-2': {
+          bookId: 'book-2',
+          payloadJson: '{}',
+          attemptCount: 0,
+          lastAttemptAt: null,
+          lastError: null,
+          createdAt: '2026-09-07T00:00:02.000Z',
+          updatedAt: '2026-09-07T00:00:02.000Z',
+        },
+      },
+      preferences: {},
+    }),
+  );
+
+  await expect(getSyncStatus()).resolves.toEqual({
+    pendingCount: 2,
+    failedCount: 1,
+    lastError: 'Kavita rejected this auth key.',
+    lastUpdatedAt: '2026-09-07T00:00:02.000Z',
+  });
 });

--- a/src/lib/database/database.ts
+++ b/src/lib/database/database.ts
@@ -529,6 +529,13 @@ export interface PendingSyncItem {
   updatedAt: string;
 }
 
+export interface SyncStatus {
+  pendingCount: number;
+  failedCount: number;
+  lastError: string | null;
+  lastUpdatedAt: string | null;
+}
+
 export async function getPendingSync(): Promise<PendingSyncItem[]> {
   if (!Capacitor.isNativePlatform()) {
     return Object.values(readBrowserState().syncQueue)
@@ -544,6 +551,33 @@ export async function getPendingSync(): Promise<PendingSyncItem[]> {
     payload: String(row.payload_json),
     updatedAt: String(row.updated_at),
   }));
+}
+
+export async function getSyncStatus(): Promise<SyncStatus> {
+  if (!Capacitor.isNativePlatform()) {
+    const rows = Object.values(readBrowserState().syncQueue).sort((a, b) =>
+      b.updatedAt.localeCompare(a.updatedAt),
+    );
+    return {
+      pendingCount: rows.length,
+      failedCount: rows.filter((row) => Boolean(row.lastError)).length,
+      lastError: rows.find((row) => row.lastError)?.lastError ?? null,
+      lastUpdatedAt: rows[0]?.updatedAt ?? null,
+    };
+  }
+  const db = await openDatabase();
+  const result = await db.query(
+    'SELECT updated_at,last_error FROM sync_queue ORDER BY updated_at DESC',
+  );
+  const rows = result.values ?? [];
+  return {
+    pendingCount: rows.length,
+    failedCount: rows.filter((row) => row.last_error).length,
+    lastError: rows.find((row) => row.last_error)?.last_error
+      ? String(rows.find((row) => row.last_error)?.last_error)
+      : null,
+    lastUpdatedAt: rows[0]?.updated_at ? String(rows[0].updated_at) : null,
+  };
 }
 
 export async function confirmSync(


### PR DESCRIPTION
## Summary
- expose pending and failed sync queue status from browser and native storage
- show queued progress updates and the latest failure in the library
- add an explicit retry action and refresh status after local progress writes

## Validation
- npm run check
- npm test -- --run
- npm run format:check
- npm run lint
