### PR TITLE
feat: add local reader highlights and notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
+- feat: add local reader highlights and notes
 - Add offline reader bookmarks and recent-location history with local CFI restoration, rename, and delete actions.
+- Add local EPUB highlights and notes with restart persistence, CFI navigation, and Markdown export.
 - Add a reproducible library virtualization benchmark for 500, 5,000, and 10,000-book datasets.
 - Align architecture, offline/sync, and security documentation with the auth-key transport, browser preview boundary, cover cache, sync preference, and current dependency override.
 - Document the iOS readiness matrix and keep platform support explicitly unverified until macOS and device checks pass.

--- a/src/lib/components/Reader.svelte
+++ b/src/lib/components/Reader.svelte
@@ -16,7 +16,20 @@
     type Appearance,
     type ReadingMode,
   } from '../reader/appearance';
-  import { ReaderSession, type ReaderLocation, type TocItem } from '../reader/session';
+  import {
+    ReaderSession,
+    type ReaderLocation,
+    type ReaderSelection,
+    type TocItem,
+  } from '../reader/session';
+  import {
+    addAnnotation,
+    annotationsMarkdown,
+    parseAnnotations,
+    removeAnnotation,
+    updateAnnotation,
+    type StoredAnnotation,
+  } from '../reader/annotations';
   import {
     parseBookmarks,
     parseLocationHistory,
@@ -56,17 +69,24 @@
   let settingsVisible = $state(false);
   let tocVisible = $state(false);
   let bookmarksVisible = $state(false);
+  let annotationsVisible = $state(false);
   let settingsPanel = $state<HTMLElement | null>(null);
   let tocPanel = $state<HTMLElement | null>(null);
   let bookmarksPanel = $state<HTMLElement | null>(null);
+  let annotationsPanel = $state<HTMLElement | null>(null);
   let settingsOpener: HTMLElement | null = null;
   let tocOpener: HTMLElement | null = null;
   let bookmarksOpener: HTMLElement | null = null;
+  let annotationsOpener: HTMLElement | null = null;
   let toc = $state<TocItem[]>([]);
   let bookmarks = $state<StoredReaderLocation[]>([]);
   let locationHistory = $state<StoredReaderLocation[]>([]);
   let editingBookmarkId = $state<string | null>(null);
   let bookmarkDraft = $state('');
+  let annotations = $state<StoredAnnotation[]>([]);
+  let selectedText = $state<ReaderSelection | null>(null);
+  let editingAnnotationId = $state<string | null>(null);
+  let annotationDraft = $state('');
   let appearance = $state<Appearance>({ ...defaultAppearance });
   let location = $state<ReaderLocation | null>(null);
   let error = $state('');
@@ -97,8 +117,11 @@
     if (destroyed) return;
     const savedHistory = await getPreference(`readerHistory:${bookId}`);
     if (destroyed) return;
+    const savedAnnotations = await getPreference(`readerAnnotations:${bookId}`);
+    if (destroyed) return;
     bookmarks = parseBookmarks(savedBookmarks);
     locationHistory = parseLocationHistory(savedHistory);
+    annotations = parseAnnotations(savedAnnotations);
     appearanceLoaded = true;
     session = new ReaderSession(bookUrl);
     try {
@@ -123,6 +146,11 @@
             if (controlsVisible) controlsVisible = false;
             else showControls();
           } else void turn(zone);
+        },
+        (selection) => {
+          if (destroyed) return;
+          selectedText = selection;
+          showControls();
         },
       );
       if (destroyed) return;
@@ -185,8 +213,10 @@
     settingsVisible = true;
     tocVisible = false;
     bookmarksVisible = false;
+    annotationsVisible = false;
     tocOpener = null;
     bookmarksOpener = null;
+    annotationsOpener = null;
     focusPanel(() => settingsPanel);
   }
 
@@ -202,8 +232,10 @@
     tocVisible = true;
     settingsVisible = false;
     bookmarksVisible = false;
+    annotationsVisible = false;
     settingsOpener = null;
     bookmarksOpener = null;
+    annotationsOpener = null;
     focusPanel(() => tocPanel);
   }
 
@@ -219,8 +251,10 @@
     bookmarksVisible = true;
     settingsVisible = false;
     tocVisible = false;
+    annotationsVisible = false;
     settingsOpener = null;
     tocOpener = null;
+    annotationsOpener = null;
     focusPanel(() => bookmarksPanel);
   }
 
@@ -229,6 +263,26 @@
     editingBookmarkId = null;
     const opener = bookmarksOpener;
     bookmarksOpener = null;
+    restoreFocus(opener);
+  }
+
+  function openAnnotations(): void {
+    annotationsOpener = activeElement();
+    annotationsVisible = true;
+    settingsVisible = false;
+    tocVisible = false;
+    bookmarksVisible = false;
+    settingsOpener = null;
+    tocOpener = null;
+    bookmarksOpener = null;
+    focusPanel(() => annotationsPanel);
+  }
+
+  function closeAnnotations(): void {
+    annotationsVisible = false;
+    editingAnnotationId = null;
+    const opener = annotationsOpener;
+    annotationsOpener = null;
     restoreFocus(opener);
   }
 
@@ -244,6 +298,7 @@
       closeSettings();
       closeToc();
       closeBookmarks();
+      closeAnnotations();
       footerVisible = false;
     }, 5_000);
   }
@@ -279,6 +334,7 @@
       .then(async () => {
         await setPreference(`readerBookmarks:${bookId}`, JSON.stringify(bookmarks));
         await setPreference(`readerHistory:${bookId}`, JSON.stringify(locationHistory));
+        await setPreference(`readerAnnotations:${bookId}`, JSON.stringify(annotations));
       })
       .catch(() => {
         // The reader remains usable when a preference write is temporarily unavailable.
@@ -313,6 +369,42 @@
     bookmarks = removeBookmark(bookmarks, bookmark.id);
     if (editingBookmarkId === bookmark.id) editingBookmarkId = null;
     persistReaderLocations();
+  }
+
+  function saveAnnotation(): void {
+    if (!selectedText) return;
+    annotations = addAnnotation(annotations, selectedText.cfi, selectedText.text, annotationDraft);
+    annotationDraft = '';
+    selectedText = null;
+    persistReaderLocations();
+  }
+
+  function editAnnotation(annotation: StoredAnnotation): void {
+    annotations = updateAnnotation(annotations, annotation.id, annotationDraft);
+    editingAnnotationId = null;
+    annotationDraft = '';
+    persistReaderLocations();
+  }
+
+  function startAnnotationEdit(annotation: StoredAnnotation): void {
+    editingAnnotationId = annotation.id;
+    annotationDraft = annotation.note;
+  }
+
+  function deleteAnnotation(annotation: StoredAnnotation): void {
+    annotations = removeAnnotation(annotations, annotation.id);
+    persistReaderLocations();
+  }
+
+  function exportAnnotations(): void {
+    if (!annotations.length) return;
+    const blob = new Blob([annotationsMarkdown(title, annotations)], { type: 'text/markdown' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `${title.replace(/[^a-z0-9]+/gi, '-').replace(/^-|-$/g, '') || 'book'}-notes.md`;
+    link.click();
+    URL.revokeObjectURL(url);
   }
 
   async function returnToLocation(saved: StoredReaderLocation): Promise<void> {
@@ -390,11 +482,15 @@
       showControls();
       return;
     }
-    if (event.key === 'Escape' && (settingsVisible || tocVisible || bookmarksVisible)) {
+    if (
+      event.key === 'Escape' &&
+      (settingsVisible || tocVisible || bookmarksVisible || annotationsVisible)
+    ) {
       event.preventDefault();
       closeSettings();
       closeToc();
       closeBookmarks();
+      closeAnnotations();
       showControls();
     }
   }
@@ -440,7 +536,7 @@
   <nav
     class="tap-zones"
     aria-label="Page navigation"
-    inert={Boolean(settingsVisible || tocVisible || bookmarksVisible)}
+    inert={Boolean(settingsVisible || tocVisible || bookmarksVisible || annotationsVisible)}
   >
     <button
       type="button"
@@ -504,10 +600,10 @@
     <div class="reader-overlay" data-controls transition:fade={{ duration: 120 }}>
       <header
         class="reader-bar reader-top"
-        inert={Boolean(settingsVisible || tocVisible || bookmarksVisible)}
+        inert={Boolean(settingsVisible || tocVisible || bookmarksVisible || annotationsVisible)}
         transition:fly={{ y: -8, duration: 140 }}
       >
-        <div class="grid w-full grid-cols-5 gap-2">
+        <div class="grid w-full grid-cols-6 gap-2">
           <button
             class="btn preset-tonal-surface min-h-12"
             type="button"
@@ -548,6 +644,17 @@
           <button
             class="btn preset-tonal-surface min-h-12"
             type="button"
+            onclick={() => (annotationsVisible ? closeAnnotations() : openAnnotations())}
+            aria-label="Open highlights and notes"
+            aria-expanded={annotationsVisible}
+            aria-controls="reader-annotations"
+          >
+            <span class="sr-only sm:not-sr-only">Notes</span>
+            <span class="sm:sr-only" aria-hidden="true">✎</span>
+          </button>
+          <button
+            class="btn preset-tonal-surface min-h-12"
+            type="button"
             onclick={() => syncLatestLocation()}
             aria-label="Sync latest reading position"
             title="Sync latest reading position"
@@ -571,14 +678,20 @@
         </p>
       </header>
 
-      {#if settingsVisible || tocVisible || bookmarksVisible}
+      {#if settingsVisible || tocVisible || bookmarksVisible || annotationsVisible}
         <button
           class="reader-panel-backdrop"
           type="button"
           tabindex="-1"
           aria-label="Close reader panel"
           onclick={() =>
-            settingsVisible ? closeSettings() : tocVisible ? closeToc() : closeBookmarks()}
+            settingsVisible
+              ? closeSettings()
+              : tocVisible
+                ? closeToc()
+                : bookmarksVisible
+                  ? closeBookmarks()
+                  : closeAnnotations()}
         ></button>
       {/if}
 
@@ -897,6 +1010,151 @@
               </div>
             {/if}
           </section>
+        </div>
+      {/if}
+
+      {#if annotationsVisible}
+        <div
+          bind:this={annotationsPanel}
+          class="reader-settings card preset-filled-surface-50-950 relative max-h-[75dvh] overflow-auto"
+          id="reader-annotations"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="reader-annotations-title"
+          tabindex="-1"
+          onkeydown={(event) => trapModalKeydown(event, annotationsPanel!, closeAnnotations)}
+          transition:fly={{ y: 12, duration: 150 }}
+        >
+          <button
+            class="btn btn-sm preset-tonal-surface absolute right-3 top-3 h-11 w-11 p-0"
+            type="button"
+            onclick={closeAnnotations}
+            aria-label="Close highlights and notes"
+            title="Close"
+          >
+            <svg aria-hidden="true" viewBox="0 0 24 24" class="h-4 w-4">
+              <path
+                fill="currentColor"
+                d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+              />
+            </svg>
+          </button>
+          <h2 id="reader-annotations-title" class="font-serif text-xl">Highlights and notes</h2>
+          <p class="mt-2 text-sm text-surface-700-300">
+            Saved on this device. Select text in the book to add a highlight and an optional note.
+          </p>
+
+          {#if selectedText}
+            <form
+              class="mt-4 rounded-lg preset-tonal-primary p-3"
+              onsubmit={(event) => {
+                event.preventDefault();
+                saveAnnotation();
+              }}
+            >
+              <p class="text-sm italic">“{selectedText.text}”</p>
+              <label class="label mt-3">
+                <span class="label-text">Note (optional)</span>
+                <textarea class="textarea min-h-20" bind:value={annotationDraft}></textarea>
+              </label>
+              <div class="mt-3 flex gap-2">
+                <button class="btn preset-filled-primary-700-300 flex-1" type="submit">
+                  Save highlight
+                </button>
+                <button
+                  class="btn preset-tonal-surface"
+                  type="button"
+                  onclick={() => {
+                    selectedText = null;
+                    annotationDraft = '';
+                  }}
+                >
+                  Cancel
+                </button>
+              </div>
+            </form>
+          {/if}
+
+          <div class="mt-4 flex items-center justify-between gap-2">
+            <h3 class="text-sm font-semibold uppercase tracking-wide">Saved highlights</h3>
+            <button
+              class="btn btn-sm preset-tonal-surface"
+              type="button"
+              onclick={exportAnnotations}
+              disabled={annotations.length === 0}
+            >
+              Export Markdown
+            </button>
+          </div>
+          {#if annotations.length === 0}
+            <p class="mt-2 text-sm text-surface-700-300">No highlights yet.</p>
+          {:else}
+            <div class="mt-2 grid gap-2">
+              {#each annotations as annotation (annotation.id)}
+                <article class="rounded-lg preset-tonal-surface p-3">
+                  <button
+                    class="w-full text-left text-sm italic"
+                    type="button"
+                    onclick={() => {
+                      void session?.displayCfi(annotation.cfi);
+                      closeAnnotations();
+                    }}
+                  >
+                    “{annotation.excerpt}”
+                  </button>
+                  {#if editingAnnotationId === annotation.id}
+                    <form
+                      class="mt-2 grid gap-2"
+                      onsubmit={(event) => {
+                        event.preventDefault();
+                        editAnnotation(annotation);
+                      }}
+                    >
+                      <label class="label">
+                        <span class="label-text">Note</span>
+                        <textarea class="textarea min-h-20" bind:value={annotationDraft}></textarea>
+                      </label>
+                      <div class="flex gap-2">
+                        <button class="btn btn-sm preset-filled-primary-700-300" type="submit">
+                          Save
+                        </button>
+                        <button
+                          class="btn btn-sm preset-tonal-surface"
+                          type="button"
+                          onclick={() => {
+                            editingAnnotationId = null;
+                            annotationDraft = '';
+                          }}
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </form>
+                  {:else}
+                    {#if annotation.note}
+                      <p class="mt-2 whitespace-pre-wrap text-sm">{annotation.note}</p>
+                    {/if}
+                    <div class="mt-2 flex justify-end gap-2">
+                      <button
+                        class="btn btn-sm preset-tonal-surface"
+                        type="button"
+                        onclick={() => startAnnotationEdit(annotation)}
+                      >
+                        Edit note
+                      </button>
+                      <button
+                        class="btn btn-sm preset-tonal-error"
+                        type="button"
+                        onclick={() => deleteAnnotation(annotation)}
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  {/if}
+                </article>
+              {/each}
+            </div>
+          {/if}
         </div>
       {/if}
     </div>

--- a/src/lib/reader/annotations.test.ts
+++ b/src/lib/reader/annotations.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import {
+  addAnnotation,
+  annotationsMarkdown,
+  parseAnnotations,
+  removeAnnotation,
+  updateAnnotation,
+} from './annotations';
+
+describe('reader annotations', () => {
+  it('ignores malformed stored values', () => {
+    expect(parseAnnotations('{"bad":true}')).toEqual([]);
+    expect(parseAnnotations('[{"id":"ok"}]')).toEqual([]);
+  });
+
+  it('adds, updates, and removes a local annotation by CFI', () => {
+    const added = addAnnotation(
+      [],
+      'epubcfi(/6/2)',
+      'A highlighted sentence',
+      'First note',
+      '2026',
+    );
+    expect(added).toHaveLength(1);
+    const updated = updateAnnotation(added, added[0]!.id, 'Updated note');
+    expect(updated[0]?.note).toBe('Updated note');
+    expect(removeAnnotation(updated, added[0]!.id)).toEqual([]);
+  });
+
+  it('exports notes without exposing HTML markup', () => {
+    const annotations = addAnnotation([], 'epubcfi(/6/2)', 'A quote', 'A note', '2026');
+    expect(annotationsMarkdown('Book', annotations)).toContain('# Notes for Book');
+    expect(annotationsMarkdown('Book', annotations)).toContain('> A quote');
+  });
+});

--- a/src/lib/reader/annotations.ts
+++ b/src/lib/reader/annotations.ts
@@ -1,0 +1,85 @@
+export interface StoredAnnotation {
+  id: string;
+  cfi: string;
+  excerpt: string;
+  note: string;
+  createdAt: string;
+}
+
+function isAnnotation(value: unknown): value is StoredAnnotation {
+  if (!value || typeof value !== 'object') return false;
+  const annotation = value as Partial<StoredAnnotation>;
+  return (
+    typeof annotation.id === 'string' &&
+    typeof annotation.cfi === 'string' &&
+    typeof annotation.excerpt === 'string' &&
+    typeof annotation.note === 'string' &&
+    typeof annotation.createdAt === 'string'
+  );
+}
+
+export function parseAnnotations(raw: string | null): StoredAnnotation[] {
+  if (!raw) return [];
+  try {
+    const value: unknown = JSON.parse(raw);
+    return Array.isArray(value) ? value.filter(isAnnotation).slice(0, 200) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function addAnnotation(
+  annotations: StoredAnnotation[],
+  cfi: string,
+  excerpt: string,
+  note: string,
+  createdAt = new Date().toISOString(),
+): StoredAnnotation[] {
+  const trimmedCfi = cfi.trim();
+  const trimmedExcerpt = excerpt.trim();
+  if (!trimmedCfi || !trimmedExcerpt) return annotations;
+  const existing = annotations.find((annotation) => annotation.cfi === trimmedCfi);
+  if (existing) {
+    return annotations.map((annotation) =>
+      annotation.id === existing.id ? { ...annotation, note: note.trim() } : annotation,
+    );
+  }
+  return [
+    ...annotations,
+    {
+      id: `${createdAt}:${trimmedCfi}`,
+      cfi: trimmedCfi,
+      excerpt: trimmedExcerpt.slice(0, 500),
+      note: note.trim().slice(0, 2000),
+      createdAt,
+    },
+  ].slice(-200);
+}
+
+export function updateAnnotation(
+  annotations: StoredAnnotation[],
+  id: string,
+  note: string,
+): StoredAnnotation[] {
+  return annotations.map((annotation) =>
+    annotation.id === id ? { ...annotation, note: note.trim().slice(0, 2000) } : annotation,
+  );
+}
+
+export function removeAnnotation(annotations: StoredAnnotation[], id: string): StoredAnnotation[] {
+  return annotations.filter((annotation) => annotation.id !== id);
+}
+
+export function annotationsMarkdown(title: string, annotations: StoredAnnotation[]): string {
+  const lines = [`# Notes for ${title}`, ''];
+  for (const annotation of annotations) {
+    lines.push(
+      `## ${annotation.createdAt}`,
+      '',
+      `> ${annotation.excerpt.replaceAll('\n', ' ')}`,
+      '',
+    );
+    if (annotation.note) lines.push(annotation.note, '');
+  }
+  return `${lines.join('\n').trim()}\n`;
+}

--- a/src/lib/reader/session.ts
+++ b/src/lib/reader/session.ts
@@ -13,6 +13,11 @@ export interface ReaderLocation {
 
 export type ReaderLocationOrigin = 'navigation' | 'restore';
 
+export interface ReaderSelection {
+  cfi: string;
+  text: string;
+}
+
 export interface TocItem {
   label: string;
   href: string;
@@ -332,6 +337,7 @@ export class ReaderSession {
   private rendition: Rendition | null = null;
   private relocated: ((location: Location) => void) | null = null;
   private contentClick: ((event: MouseEvent, contents: Contents) => void) | null = null;
+  private selectionListeners: Array<() => void> = [];
   private current: Location | null = null;
   private userNavigationPending = false;
   private onLocation: ((location: ReaderLocation, origin: ReaderLocationOrigin) => void) | null =
@@ -349,6 +355,7 @@ export class ReaderSession {
     appearance: Appearance,
     onLocation: (location: ReaderLocation, origin: ReaderLocationOrigin) => void,
     onTap: (zone: 'previous' | 'center' | 'next') => void,
+    onSelection?: (selection: ReaderSelection) => void,
   ): Promise<void> {
     this.rendition = this.book.renderTo(target, {
       width: '100%',
@@ -359,6 +366,25 @@ export class ReaderSession {
       allowScriptedContent: false,
     });
     this.rendition.hooks.content.register((contents: Contents) => this.harden(contents));
+    if (onSelection) {
+      this.rendition.hooks.content.register((contents: Contents) => {
+        const handler = () => {
+          const selection = contents.window.getSelection();
+          if (!selection || selection.isCollapsed || !selection.rangeCount) return;
+          const text = selection.toString().replace(/\s+/g, ' ').trim();
+          if (!text) return;
+          try {
+            onSelection({ cfi: contents.cfiFromRange(selection.getRangeAt(0)), text });
+          } catch {
+            // Selection can change while a section is being replaced.
+          }
+        };
+        contents.document.addEventListener('selectionchange', handler);
+        this.selectionListeners.push(() =>
+          contents.document.removeEventListener('selectionchange', handler),
+        );
+      });
+    }
     this.onLocation = onLocation;
     this.relocated = (location) => {
       this.current = location;
@@ -502,6 +528,8 @@ export class ReaderSession {
     if (this.rendition && this.relocated) this.rendition.off('relocated', this.relocated);
     if (this.rendition && this.contentClick) this.rendition.off('click', this.contentClick);
     this.rendition?.destroy();
+    this.selectionListeners.forEach((remove) => remove());
+    this.selectionListeners = [];
     this.rendition = null;
     this.relocated = null;
     this.contentClick = null;


### PR DESCRIPTION
## Summary
- capture text selections as EPUB CFI highlights
- persist local notes and highlights across restarts
- navigate back to highlights, edit/delete notes, and export Markdown

## Validation
- npm run check
- npm run lint
- npm run format:check
- npm test -- --run
