### PR TITLE
security: reject unexpected Kavita redirects

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
+- security: reject unexpected Kavita redirects
 - Add offline reader bookmarks and recent-location history with local CFI restoration, rename, and delete actions.
+- Reject unexpected Kavita HTTP redirects in browser and native requests.
 - Add a reproducible library virtualization benchmark for 500, 5,000, and 10,000-book datasets.
 - Align architecture, offline/sync, and security documentation with the auth-key transport, browser preview boundary, cover cache, sync preference, and current dependency override.
 - Document the iOS readiness matrix and keep platform support explicitly unverified until macOS and device checks pass.

--- a/src/lib/kavita/client.test.ts
+++ b/src/lib/kavita/client.test.ts
@@ -43,6 +43,7 @@ it('loads covers with the api key header', async () => {
   expect(fetch).toHaveBeenCalledWith(
     'https://books.example.com/api/Image/series-cover?seriesId=4',
     expect.objectContaining({
+      redirect: 'error',
       headers: expect.objectContaining({
         'x-api-key': 'abc123',
       }),
@@ -60,6 +61,7 @@ it('requests the Kavita series list with POST', async () => {
     'https://books.example.com/api/Series/v2?PageNumber=1&PageSize=500',
     expect.objectContaining({
       method: 'POST',
+      redirect: 'error',
       headers: expect.objectContaining({
         'x-api-key': 'abc123',
       }),

--- a/src/lib/kavita/client.ts
+++ b/src/lib/kavita/client.ts
@@ -126,6 +126,7 @@ export class KavitaClient {
         url,
         headers: { 'x-api-key': this.apiKey },
         responseType: 'blob',
+        disableRedirects: true,
         connectTimeout: REQUEST_TIMEOUT_MS,
         readTimeout: REQUEST_TIMEOUT_MS,
       });
@@ -152,6 +153,7 @@ export class KavitaClient {
       const combined = signal ? AbortSignal.any([signal, timeout.signal]) : timeout.signal;
       const response = await fetch(url, {
         signal: combined,
+        redirect: 'error',
         headers: { 'x-api-key': this.apiKey },
       });
       if (!response.ok) throw new KavitaError('The book cover could not be loaded.', 'server');
@@ -205,6 +207,7 @@ export class KavitaClient {
       const response = await fetch(this.resolveUrl(path), {
         ...init,
         signal,
+        redirect: 'error',
         headers: {
           Accept: 'application/json',
           'Content-Type': 'application/json',
@@ -255,6 +258,7 @@ export class KavitaClient {
       },
       connectTimeout: REQUEST_TIMEOUT_MS,
       readTimeout: REQUEST_TIMEOUT_MS,
+      disableRedirects: true,
     };
     if (typeof init.body === 'string') options.data = JSON.parse(init.body) as unknown;
     try {


### PR DESCRIPTION
## Summary
- reject browser fetch redirects for Kavita API and cover requests
- disable native Capacitor HTTP redirects for the same requests
- keep redirect behavior covered by client tests

## Validation
- npm run check
- npm run lint
- npm run format:check
- npm test -- --run
