### PR TITLE
test: cover metadata refresh with real sqlite

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- test: run sqlite integration in node
 - test: cover metadata refresh with real sqlite
 - security: reject unexpected Kavita redirects
 - Add offline reader bookmarks and recent-location history with local CFI restoration, rename, and delete actions.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,8 +2,10 @@
 
 ## Unreleased
 
+- test: cover metadata refresh with real sqlite
 - security: reject unexpected Kavita redirects
 - Add offline reader bookmarks and recent-location history with local CFI restoration, rename, and delete actions.
+- Exercise native metadata refresh and removal reconciliation against real in-memory SQLite transactions.
 - Reject unexpected Kavita HTTP redirects in browser and native requests.
 - Add a reproducible library virtualization benchmark for 500, 5,000, and 10,000-book datasets.
 - Align architecture, offline/sync, and security documentation with the auth-key transport, browser preview boundary, cover cache, sync preference, and current dependency override.

--- a/src/lib/database/database.sqlite.test.ts
+++ b/src/lib/database/database.sqlite.test.ts
@@ -1,0 +1,147 @@
+import { DatabaseSync } from 'node:sqlite';
+import type { SQLInputValue } from 'node:sqlite';
+import type { capTask } from '@capacitor-community/sqlite';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  reconcileBooksInTransaction,
+  replaceBooksInTransaction,
+  type BookRecord,
+} from './database';
+import { migrations } from './schema';
+
+const baseBook: BookRecord = {
+  id: 'server:1:10',
+  serverId: 'server',
+  libraryId: 1,
+  seriesId: 1,
+  volumeId: 10,
+  chapterId: 10,
+  title: 'Book',
+  author: 'Author',
+  series: 'Series',
+  descriptionHtml: '<p>Description</p>',
+  format: 'epub',
+  pages: 100,
+  pagesRead: 10,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  lastReadAt: '2026-01-02T00:00:00.000Z',
+  downloadPath: 'books/book.epub',
+  downloadStatus: 'available',
+  fileSize: 1234,
+};
+
+function createDatabase(): DatabaseSync {
+  const db = new DatabaseSync(':memory:');
+  db.exec('PRAGMA foreign_keys = ON;');
+  for (const migration of migrations) db.exec(migration.statements);
+  db.prepare(
+    `INSERT INTO server_config
+      (id, display_name, base_url, credential_ref, kavita_version, last_connected_at)
+      VALUES (?, ?, ?, ?, ?, ?)`,
+  ).run(
+    'server',
+    'Test server',
+    'https://books.example.com',
+    'credential',
+    null,
+    baseBook.createdAt,
+  );
+  return db;
+}
+
+function createAdapter(
+  db: DatabaseSync,
+): Pick<Parameters<typeof replaceBooksInTransaction>[0], 'executeTransaction'> {
+  return {
+    executeTransaction(tasks: capTask[]): Promise<{ changes: { changes: number } }> {
+      db.exec('BEGIN');
+      try {
+        for (const task of tasks) {
+          const statement = db.prepare(task.statement);
+          statement.run(...((task.values ?? []) as SQLInputValue[]));
+        }
+        db.exec('COMMIT');
+        return Promise.resolve({ changes: { changes: tasks.length } });
+      } catch (error) {
+        db.exec('ROLLBACK');
+        throw error;
+      }
+    },
+  };
+}
+
+function readBook(db: DatabaseSync, id: string): Record<string, unknown> | undefined {
+  return db.prepare('SELECT * FROM books WHERE id=?').get(id) as
+    Record<string, unknown> | undefined;
+}
+
+describe('native metadata transactions against SQLite', () => {
+  let db: DatabaseSync;
+
+  afterEach(() => db.close());
+
+  it('commits a refresh while retaining local download columns', async () => {
+    db = createDatabase();
+    const adapter = createAdapter(db);
+    await replaceBooksInTransaction(adapter, 'server', [baseBook], '2026-09-08T00:00:00.000Z');
+    const refreshed = {
+      ...baseBook,
+      title: 'Updated title',
+      downloadPath: null,
+      downloadStatus: 'none',
+      fileSize: null,
+    };
+
+    await replaceBooksInTransaction(adapter, 'server', [refreshed], '2026-09-09T00:00:00.000Z');
+
+    expect(readBook(db, baseBook.id)).toMatchObject({
+      title: 'Updated title',
+      download_path: baseBook.downloadPath,
+      download_status: baseBook.downloadStatus,
+      file_size: baseBook.fileSize,
+      metadata_refreshed_at: '2026-09-09T00:00:00.000Z',
+    });
+  });
+
+  it('rolls back every task when a later metadata row violates SQLite constraints', async () => {
+    db = createDatabase();
+    const adapter = createAdapter(db);
+    await replaceBooksInTransaction(adapter, 'server', [baseBook], '2026-09-08T00:00:00.000Z');
+    const invalid = {
+      ...baseBook,
+      id: 'server:1:11',
+      chapterId: 11,
+      title: null as unknown as string,
+    };
+
+    await expect(
+      replaceBooksInTransaction(adapter, 'server', [
+        { ...baseBook, title: 'First update' },
+        invalid,
+      ]),
+    ).rejects.toThrow();
+
+    expect(readBook(db, baseBook.id)).toMatchObject({ title: 'Book' });
+    expect(readBook(db, invalid.id)).toBeUndefined();
+  });
+
+  it('marks retained removals unavailable and deletes unretained removals atomically', async () => {
+    db = createDatabase();
+    const adapter = createAdapter(db);
+    const retained = { ...baseBook, id: 'server:1:10' };
+    const removable = {
+      ...baseBook,
+      id: 'server:1:11',
+      chapterId: 11,
+      downloadPath: null,
+      downloadStatus: 'none',
+      fileSize: null,
+    };
+    await replaceBooksInTransaction(adapter, 'server', [retained, removable]);
+
+    await reconcileBooksInTransaction(adapter, 'server', [], '2026-09-10T00:00:00.000Z');
+
+    expect(readBook(db, retained.id)).toMatchObject({ remote_available: 0 });
+    expect(readBook(db, removable.id)).toBeUndefined();
+  });
+});

--- a/src/lib/database/database.sqlite.test.ts
+++ b/src/lib/database/database.sqlite.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { DatabaseSync } from 'node:sqlite';
 import type { SQLInputValue } from 'node:sqlite';
 import type { capTask } from '@capacitor-community/sqlite';


### PR DESCRIPTION
## Summary
- run native metadata refresh tests against Node's real SQLite engine
- verify local download fields survive refreshes
- verify constraint failures roll back all metadata tasks
- verify retained and removable books reconcile atomically

## Validation
- npm run check
- npm run lint
- npm run format:check
- npm test -- --run src/lib/database/database.sqlite.test.ts
