### PR TITLE
docs: add Android device validation checklist

### DIFF
--- a/DEVICE_VALIDATION.md
+++ b/DEVICE_VALIDATION.md
@@ -1,0 +1,58 @@
+# Device validation checklist
+
+This checklist covers the Android device and emulator checks that complement the automated web, SQLite, EPUB, and Android startup tests. Record the device, Android version, app commit, and date with every run. The checklist deliberately avoids treating a passing build as proof of accessibility or network isolation.
+
+## Automated checks
+
+Run these from a clean checkout before the device pass:
+
+```sh
+npm ci
+npm run check
+npm run lint
+npm run format:check
+npm test -- --run
+npm run android:debug
+npm run android:smoke
+```
+
+`android:smoke` installs the debug APK, starts `app.turnleaf.reader/.MainActivity`, and verifies that the application process stays alive. The CI emulator job runs the same script on an API 35 Google APIs x86_64 image.
+
+## Android accessibility pass
+
+Use a physical Android device when possible; otherwise use the CI emulator image. Enable TalkBack and large display/text settings before opening the app.
+
+1. From onboarding, move through every field and action with TalkBack swipe navigation. Each control must have a useful spoken label, and focus must remain visible after opening or closing a panel.
+2. In the library, open settings, the book actions menu, and the conflict dialog. Confirm that focus enters the dialog, stays inside while tabbing or swiping, closes with Back/Escape, and returns to the opener after filtering or deleting a book.
+3. In the reader, use the Contents, Text, Marks, Notes, and Sync controls. Confirm that each toggle announces its expanded state and that the panel title is announced once. Verify that the page controls remain available without relying on the three tap zones.
+4. Set text and display size to 200% and rotate between portrait and landscape. Essential labels, progress, dialogs, and close controls must remain reachable without horizontal clipping or overlap.
+5. Test light, dark, and e-ink themes with keyboard focus and TalkBack. Selected modes must have a state cue in addition to color, and all primary controls must remain at least 44 CSS pixels (the app uses 48px compact targets for these controls).
+6. Select a passage in an EPUB, save a local note, navigate to its highlight, edit it, export Markdown, close the reader, and reopen it. TalkBack must be able to reach the note form and saved annotation actions.
+
+Record any failure with a screenshot, the spoken label, the focused element, and the exact reproduction path. A passing automated test suite does not replace this step.
+
+## Network and content isolation pass
+
+Use a test server that can return a redirect, an HTTPS-to-HTTP downgrade, malformed JSON, an HTML error body, and a valid EPUB containing remote image/CSS/navigation references.
+
+1. Configure the server URL and confirm that the normal API, cover, download, and progress requests include the auth header only on the intended Kavita origin.
+2. Return a cross-origin redirect and an HTTPS downgrade from each authenticated endpoint. The browser client, native client, and cover loader must fail the request without sending the auth header to the redirected origin.
+3. Open the hostile EPUB fixture and capture WebView requests. No script, form submission, remote stylesheet, remote image, SVG resource, media poster, or external navigation may execute or receive the auth key. Internal chapter, fragment, and local stylesheet links must continue to work.
+4. Interrupt an EPUB download and verify that the partial file is not advertised as available. Reopen the app offline and confirm that a previously completed EPUB remains readable.
+
+For Android, capture the WebView request log or a proxy trace with the test server origin and destination redacted only after verifying that no credentials appear. Store the result with the release candidate’s validation record.
+
+## Result record
+
+Use this small record in the release checklist or PR description:
+
+| Field                         | Value                 |
+| ----------------------------- | --------------------- |
+| Commit / version              |                       |
+| Device or emulator image      |                       |
+| Android version               |                       |
+| TalkBack version and settings |                       |
+| Automated checks              | pass / fail           |
+| Accessibility pass            | pass / fail / blocked |
+| Network isolation pass        | pass / fail / blocked |
+| Defects / follow-up           |                       |

--- a/FUTURE_WORK_PLAN.md
+++ b/FUTURE_WORK_PLAN.md
@@ -261,6 +261,19 @@ Reconcile claims with code and validated behavior, especially sync triggers, res
 
 Acceptance: documentation walkthrough from clean install to offline reading matches the app; referenced package versions agree with the lockfile; release notes distinguish implementation from device verification; a release checklist records remaining platform limitations.
 
+## Implementation status
+
+The remaining implementable items from this plan are split into focused pull requests:
+
+- F1 residual discovery controls: [#89](https://github.com/sgerner/turnleaf/pull/89).
+- F3 in-book search: [#90](https://github.com/sgerner/turnleaf/pull/90); local highlights, notes, and Markdown export: [#91](https://github.com/sgerner/turnleaf/pull/91).
+- S2 authenticated redirect hardening: [#92](https://github.com/sgerner/turnleaf/pull/92).
+- T2 real SQLite transaction coverage: [#93](https://github.com/sgerner/turnleaf/pull/93); Android emulator startup smoke: [#94](https://github.com/sgerner/turnleaf/pull/94).
+- Android accessibility, network-isolation, and offline-reopen procedure: [DEVICE_VALIDATION.md](DEVICE_VALIDATION.md) and [#95](https://github.com/sgerner/turnleaf/pull/95).
+- P4 native library query index and query-plan coverage: [#96](https://github.com/sgerner/turnleaf/pull/96).
+
+Automated checks cover the code paths available in this environment. TalkBack behavior, WebView network traces, and named-device performance measurements still require an Android device or a completed emulator acceptance run; record those results with the checklist. iOS readiness and the deferred product decisions remain intentionally outside this implementation batch.
+
 ## Deferred product decisions
 
 - Multi-server profiles: onboarding currently uses a fixed `primary` identity. Validate demand before expanding it; first require server-scoped queues, cache keys, credentials, and offline data isolation.

--- a/README.md
+++ b/README.md
@@ -250,6 +250,8 @@ Please keep changes small and direct:
 
 GitHub Actions runs pull-request checks for formatting, linting, type checking, tests, the web build, dependency review, CodeQL scanning, and an Android debug build. PRs that touch native behavior should also be verified locally on the relevant platform when possible.
 
+Use [DEVICE_VALIDATION.md](DEVICE_VALIDATION.md) for the Android accessibility, network-isolation, and offline-reopen acceptance pass. CI also runs an emulator startup smoke test; that smoke test does not replace TalkBack or network-trace validation.
+
 Before opening a pull request, run:
 
 ```bash

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
+- docs: add Android device validation checklist
 - Add offline reader bookmarks and recent-location history with local CFI restoration, rename, and delete actions.
+- Add a reproducible Android accessibility, network isolation, and offline reopen validation checklist.
 - Add a reproducible library virtualization benchmark for 500, 5,000, and 10,000-book datasets.
 - Align architecture, offline/sync, and security documentation with the auth-key transport, browser preview boundary, cover cache, sync preference, and current dependency override.
 - Document the iOS readiness matrix and keep platform support explicitly unverified until macOS and device checks pass.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- docs: record remaining work implementation status
 - docs: add Android device validation checklist
 - Add offline reader bookmarks and recent-location history with local CFI restoration, rename, and delete actions.
 - Add a reproducible Android accessibility, network isolation, and offline reopen validation checklist.


### PR DESCRIPTION
## Summary
- add a reproducible Android accessibility and TalkBack acceptance checklist
- document redirect, EPUB resource-isolation, offline-reopen, and network-trace checks
- record device, emulator, and release-candidate results without treating startup smoke as full acceptance

## Validation
- npm run check
- npm run lint
- npm run format:check
- npm test -- --run
