### PR TITLE
perf: index native library title reads

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
+- perf: index native library title reads
 - Add offline reader bookmarks and recent-location history with local CFI restoration, rename, and delete actions.
+- Add a server-scoped native library title index with migration and query-plan coverage.
 - Add a reproducible library virtualization benchmark for 500, 5,000, and 10,000-book datasets.
 - Align architecture, offline/sync, and security documentation with the auth-key transport, browser preview boundary, cover cache, sync preference, and current dependency override.
 - Document the iOS readiness matrix and keep platform support explicitly unverified until macOS and device checks pass.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- test: update migration coverage for library index
 - perf: index native library title reads
 - Add offline reader bookmarks and recent-location history with local CFI restoration, rename, and delete actions.
 - Add a server-scoped native library title index with migration and query-plan coverage.

--- a/src/lib/database/database.native.test.ts
+++ b/src/lib/database/database.native.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, expect, it, vi } from 'vitest';
 import type { capSQLiteChanges, capTask } from '@capacitor-community/sqlite';
 
 const mocks = vi.hoisted(() => {
-  let databaseVersion = 4;
+  let databaseVersion = 5;
   const executeTransaction = vi.fn<(tasks: capTask[]) => Promise<capSQLiteChanges>>(async () => ({
     changes: { changes: 0 },
   }));
@@ -24,7 +24,7 @@ const mocks = vi.hoisted(() => {
     db,
     executeTransaction,
     reset() {
-      databaseVersion = 4;
+      databaseVersion = 5;
       vi.clearAllMocks();
     },
     setDatabaseVersion(version: number) {
@@ -151,18 +151,20 @@ it('records each migration and its user version in one transaction', async () =>
 
   await openDatabase();
 
-  expect(mocks.executeTransaction).toHaveBeenCalledTimes(4);
+  expect(mocks.executeTransaction).toHaveBeenCalledTimes(5);
   const migrationTasks = mocks.executeTransaction.mock.calls.map(([tasks]) => tasks);
   expect(migrationTasks.map((tasks) => tasks?.[0]?.statement)).toEqual([
     expect.stringContaining('CREATE TABLE IF NOT EXISTS server_config'),
     expect.stringContaining('ALTER TABLE books ADD COLUMN pages'),
     expect.stringContaining('CREATE TABLE preferences'),
     expect.stringContaining('ALTER TABLE books ADD COLUMN remote_available'),
+    expect.stringContaining('CREATE INDEX IF NOT EXISTS books_server_title_idx'),
   ]);
   expect(migrationTasks.map((tasks) => tasks?.[1]?.statement)).toEqual([
     'PRAGMA user_version = 1;',
     'PRAGMA user_version = 2;',
     'PRAGMA user_version = 3;',
     'PRAGMA user_version = 4;',
+    'PRAGMA user_version = 5;',
   ]);
 });

--- a/src/lib/database/schema.index.test.ts
+++ b/src/lib/database/schema.index.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment node
+
+import { DatabaseSync } from 'node:sqlite';
+import { afterEach, describe, expect, it } from 'vitest';
+import { migrations } from './schema';
+
+describe('native library indexes', () => {
+  let db: DatabaseSync;
+
+  afterEach(() => db.close());
+
+  it('adds a server-scoped title index for ordered library reads', () => {
+    db = new DatabaseSync(':memory:');
+    db.exec(
+      migrations
+        .slice(0, 4)
+        .map((migration) => migration.statements)
+        .join('\n'),
+    );
+    db.exec(migrations[4]!.statements);
+
+    const indexes = db.prepare("PRAGMA index_list('books')").all() as Array<{
+      name: string;
+    }>;
+    expect(indexes.map((index) => index.name)).toContain('books_server_title_idx');
+
+    const plan = db
+      .prepare('EXPLAIN QUERY PLAN SELECT * FROM books WHERE server_id=? ORDER BY title')
+      .all('server') as Array<{ detail: string }>;
+    expect(plan.some((row) => row.detail.includes('books_server_title_idx'))).toBe(true);
+  });
+});

--- a/src/lib/database/schema.ts
+++ b/src/lib/database/schema.ts
@@ -84,4 +84,10 @@ export const migrations = [
       ALTER TABLE books ADD COLUMN remote_available INTEGER NOT NULL DEFAULT 1;
     `,
   },
+  {
+    version: 5,
+    statements: `
+      CREATE INDEX IF NOT EXISTS books_server_title_idx ON books(server_id, title, id);
+    `,
+  },
 ] as const;


### PR DESCRIPTION
## Summary
- add a v5 SQLite migration for `(server_id, title, id)` library reads
- verify the index exists and is selected by SQLite's query planner
- keep ordering deterministic for equal titles

## Validation
- npm run check
- npm run lint
- npm run format:check
- npm test -- --run src/lib/database/schema.index.test.ts
