### PR TITLE
Serialize native SQLite transactions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: serialize native sqlite transactions
 - fix: publish releases without a checkout
 - fix: normalize finalized release notes
 - ci: use software-compatible Android smoke image

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: serialize all native database writes
 - fix: serialize native sqlite transactions
 - fix: publish releases without a checkout
 - fix: normalize finalized release notes

--- a/src/lib/database/database.native.test.ts
+++ b/src/lib/database/database.native.test.ts
@@ -121,6 +121,33 @@ it('serializes concurrent native progress transactions', async () => {
   expect(mocks.executeTransaction).toHaveBeenCalledTimes(2);
 });
 
+it('serializes direct native writes with transactions', async () => {
+  let activeWrites = 0;
+  let peakWrites = 0;
+  const delay = async (): Promise<void> => {
+    activeWrites += 1;
+    peakWrites = Math.max(peakWrites, activeWrites);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    activeWrites -= 1;
+  };
+  mocks.executeTransaction.mockImplementation(async () => {
+    await delay();
+    return { changes: { changes: 0 } };
+  });
+  mocks.db.run.mockImplementation(async () => {
+    await delay();
+    return { changes: { changes: 0 } };
+  });
+
+  const { markSyncFailure, saveLocalProgress } = await import('./database');
+  await Promise.all([
+    saveLocalProgress(book, readingState.cfi, readingState.xpath, 0.4),
+    markSyncFailure(book.id, 'offline'),
+  ]);
+
+  expect(peakWrites).toBe(1);
+});
+
 it('keeps a failed native progress transaction atomic', async () => {
   const persisted = { book: false, readingState: false, syncQueue: false };
   mocks.executeTransaction.mockImplementationOnce(async (tasks: capTask[]) => {

--- a/src/lib/database/database.native.test.ts
+++ b/src/lib/database/database.native.test.ts
@@ -100,6 +100,27 @@ it('groups progress, queue, and book updates into one native transaction', async
   ]);
 });
 
+it('serializes concurrent native progress transactions', async () => {
+  let activeTransactions = 0;
+  let peakTransactions = 0;
+  mocks.executeTransaction.mockImplementation(async () => {
+    activeTransactions += 1;
+    peakTransactions = Math.max(peakTransactions, activeTransactions);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    activeTransactions -= 1;
+    return { changes: { changes: 0 } };
+  });
+
+  const { saveLocalProgress } = await import('./database');
+  await Promise.all([
+    saveLocalProgress(book, readingState.cfi, readingState.xpath, 0.4),
+    saveLocalProgress(book, readingState.cfi, readingState.xpath, 0.5),
+  ]);
+
+  expect(peakTransactions).toBe(1);
+  expect(mocks.executeTransaction).toHaveBeenCalledTimes(2);
+});
+
 it('keeps a failed native progress transaction atomic', async () => {
   const persisted = { book: false, readingState: false, syncQueue: false };
   mocks.executeTransaction.mockImplementationOnce(async (tasks: capTask[]) => {

--- a/src/lib/database/database.ts
+++ b/src/lib/database/database.ts
@@ -65,15 +65,35 @@ interface BrowserDatabaseState {
 
 const BROWSER_STORAGE_KEY = 'turnleaf_browser_database_v1';
 
+function enqueueNativeWrite<T>(operation: () => Promise<T>): Promise<T> {
+  const next = nativeTransactionQueue.then(operation);
+  nativeTransactionQueue = next.then(
+    () => undefined,
+    () => undefined,
+  );
+  return next;
+}
+
 async function executeNativeTransaction(
   db: Pick<SQLiteDBConnection, 'executeTransaction'>,
   tasks: capTask[],
 ): Promise<void> {
-  const next = nativeTransactionQueue.then(() =>
-    db.executeTransaction(tasks).then(() => undefined),
-  );
-  nativeTransactionQueue = next.catch(() => undefined);
-  await next;
+  await enqueueNativeWrite(() => db.executeTransaction(tasks).then(() => undefined));
+}
+
+async function executeNativeRun(
+  db: Pick<SQLiteDBConnection, 'run'>,
+  statement: string,
+  values: unknown[] = [],
+): Promise<void> {
+  await enqueueNativeWrite(() => db.run(statement, values).then(() => undefined));
+}
+
+async function executeNativeStatement(
+  db: Pick<SQLiteDBConnection, 'execute'>,
+  statement: string,
+): Promise<void> {
+  await enqueueNativeWrite(() => db.execute(statement).then(() => undefined));
 }
 
 function createBrowserState(): BrowserDatabaseState {
@@ -139,7 +159,7 @@ async function openNativeDatabase(): Promise<SQLiteDBConnection> {
       ? await sqlite.retrieveConnection('turnleaf', false)
       : await sqlite.createConnection('turnleaf', false, 'no-encryption', 1, false);
   await db.open();
-  await db.execute('PRAGMA foreign_keys = ON;');
+  await executeNativeStatement(db, 'PRAGMA foreign_keys = ON;');
   await migrate(db);
   return db;
 }
@@ -185,7 +205,8 @@ export async function saveServer(config: ServerConfig): Promise<void> {
     return;
   }
   const db = await openDatabase();
-  await db.run(
+  await executeNativeRun(
+    db,
     `INSERT OR REPLACE INTO server_config
       (id, display_name, base_url, credential_ref, kavita_version, last_connected_at)
       VALUES (?, ?, ?, ?, ?, ?)`,
@@ -213,7 +234,7 @@ export async function removeServer(serverId: string): Promise<void> {
     return;
   }
   const db = await openDatabase();
-  await db.run('DELETE FROM server_config WHERE id=?', [serverId]);
+  await executeNativeRun(db, 'DELETE FROM server_config WHERE id=?', [serverId]);
 }
 
 export async function getServer(): Promise<ServerConfig | null> {
@@ -430,7 +451,8 @@ export async function markDownloaded(bookId: string, path: string, size: number)
     return;
   }
   const db = await openDatabase();
-  await db.run(
+  await executeNativeRun(
+    db,
     "UPDATE books SET download_path=?, download_status='available', file_size=? WHERE id=?",
     [path, size, bookId],
   );
@@ -734,7 +756,8 @@ export async function markSyncFailure(bookId: string, error: string): Promise<vo
     return;
   }
   const db = await openDatabase();
-  await db.run(
+  await executeNativeRun(
+    db,
     `UPDATE sync_queue SET attempt_count=attempt_count+1,last_attempt_at=?,last_error=?
     WHERE book_id=?`,
     [new Date().toISOString(), error.slice(0, 240), bookId],
@@ -753,7 +776,8 @@ export async function removeDownload(bookId: string): Promise<void> {
     return;
   }
   const db = await openDatabase();
-  await db.run(
+  await executeNativeRun(
+    db,
     "UPDATE books SET download_path=NULL,download_status='none',file_size=NULL WHERE id=?",
     [bookId],
   );
@@ -776,7 +800,8 @@ export async function setPreference(key: string, value: string): Promise<void> {
     return;
   }
   const db = await openDatabase();
-  await db.run(
+  await executeNativeRun(
+    db,
     `INSERT INTO preferences (key,value,updated_at) VALUES (?,?,?)
     ON CONFLICT(key) DO UPDATE SET value=excluded.value,updated_at=excluded.updated_at`,
     [key, value, new Date().toISOString()],

--- a/src/lib/database/database.ts
+++ b/src/lib/database/database.ts
@@ -42,6 +42,7 @@ export interface BookRecord {
 
 let connection: SQLiteDBConnection | null = null;
 let opening: Promise<SQLiteDBConnection> | null = null;
+let nativeTransactionQueue: Promise<void> = Promise.resolve();
 
 interface BrowserDatabaseState {
   serverConfig: ServerConfig | null;
@@ -63,6 +64,17 @@ interface BrowserDatabaseState {
 }
 
 const BROWSER_STORAGE_KEY = 'turnleaf_browser_database_v1';
+
+async function executeNativeTransaction(
+  db: Pick<SQLiteDBConnection, 'executeTransaction'>,
+  tasks: capTask[],
+): Promise<void> {
+  const next = nativeTransactionQueue.then(() =>
+    db.executeTransaction(tasks).then(() => undefined),
+  );
+  nativeTransactionQueue = next.catch(() => undefined);
+  await next;
+}
 
 function createBrowserState(): BrowserDatabaseState {
   return {
@@ -158,7 +170,7 @@ async function migrate(db: SQLiteDBConnection): Promise<void> {
   const current = await db.getVersion();
   for (const migration of migrations) {
     if (migration.version <= (current.version ?? 0)) continue;
-    await db.executeTransaction([
+    await executeNativeTransaction(db, [
       { statement: migration.statements },
       { statement: `PRAGMA user_version = ${migration.version};` },
     ]);
@@ -339,7 +351,10 @@ export async function replaceBooksInTransaction(
   refreshedAt = new Date().toISOString(),
 ): Promise<void> {
   if (books.length === 0) return;
-  await db.executeTransaction(books.map((book) => replaceBookTask(serverId, book, refreshedAt)));
+  await executeNativeTransaction(
+    db,
+    books.map((book) => replaceBookTask(serverId, book, refreshedAt)),
+  );
 }
 
 const retainedBookCondition = `(download_path IS NOT NULL OR download_status='available'
@@ -357,7 +372,7 @@ export async function reconcileBooksInTransaction(
   const ids = books.map((book) => book.id);
   const absent = ids.length ? `id NOT IN (${ids.map(() => '?').join(',')})` : '1=1';
   const values = [serverId, ...ids];
-  await db.executeTransaction([
+  await executeNativeTransaction(db, [
     ...books.map((book) => replaceBookTask(serverId, book, refreshedAt)),
     {
       statement: `UPDATE books SET remote_available=0 WHERE server_id=? AND ${absent}
@@ -547,7 +562,7 @@ export async function saveLocalProgress(
     pageNum: pagesRead,
     bookScrollId: xpath,
   };
-  await db.executeTransaction([
+  await executeNativeTransaction(db, [
     createReadingStateTask(book.id, cfi, xpath, percentage, now),
     createSyncQueueTask(book.id, payload, now),
     {
@@ -612,7 +627,7 @@ export async function markBookCompleted(
     tasks.push(createReadingStateTask(book.id, readingState.cfi, readingState.xpath, 1, now));
   }
   tasks.push(createSyncQueueTask(book.id, payload, now));
-  await db.executeTransaction(tasks);
+  await executeNativeTransaction(db, tasks);
 }
 
 export interface PendingSyncItem {
@@ -692,7 +707,7 @@ export async function confirmSync(
     return;
   }
   const db = await openDatabase();
-  await db.executeTransaction([
+  await executeNativeTransaction(db, [
     {
       statement: `UPDATE reading_state SET pending_sync=0,synced_local_updated_at=local_updated_at,
         server_updated_at=? WHERE book_id=? AND local_updated_at=?


### PR DESCRIPTION
## Problem
Rapid reader navigation can overlap native SQLite transactions on Android. The Capacitor SQLite plugin reports `Already in transaction` / `no current transaction`, which can drop progress or sync writes.

## Change
- serialize every native SQLite write through one promise queue
- cover grouped `executeTransaction` calls and standalone `run`/`execute` writes
- keep grouped progress, sync, metadata, and migration updates atomic
- add regression coverage for transaction and direct-write overlap

## Validation
- `npm test` (27 files, 138 tests)
- `npm run check`
- `npm run lint`
- `npm run format:check`
- signed Android build installed on Pixel 6 over ADB
- five rapid page turns after an idle reader session produced no SQLite transaction errors in logcat
