### PR TITLE
Keep reader panels open while in use

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Keep reader panels open while in use
 - fix: publish releases without a checkout
 - fix: normalize finalized release notes
 - ci: use software-compatible Android smoke image

--- a/src/lib/components/Reader.svelte
+++ b/src/lib/components/Reader.svelte
@@ -218,7 +218,23 @@
     void tick().then(() => focusFirstElement(getPanel()));
   }
 
+  function hasOpenReaderPanel(): boolean {
+    return settingsVisible || tocVisible || bookmarksVisible || annotationsVisible || searchVisible;
+  }
+
+  function pauseChromeHide(): void {
+    if (hideTimer !== null) {
+      window.clearTimeout(hideTimer);
+      hideTimer = null;
+    }
+  }
+
+  function resumeChromeHide(): void {
+    if (controlsVisible && !hasOpenReaderPanel()) scheduleChromeHide();
+  }
+
   function openSettings(): void {
+    pauseChromeHide();
     settingsOpener = activeElement();
     settingsVisible = true;
     tocVisible = false;
@@ -237,9 +253,11 @@
     const opener = settingsOpener;
     settingsOpener = null;
     restoreFocus(opener);
+    resumeChromeHide();
   }
 
   function openToc(): void {
+    pauseChromeHide();
     tocOpener = activeElement();
     tocVisible = true;
     settingsVisible = false;
@@ -258,9 +276,11 @@
     const opener = tocOpener;
     tocOpener = null;
     restoreFocus(opener);
+    resumeChromeHide();
   }
 
   function openBookmarks(): void {
+    pauseChromeHide();
     bookmarksOpener = activeElement();
     bookmarksVisible = true;
     settingsVisible = false;
@@ -280,9 +300,11 @@
     const opener = bookmarksOpener;
     bookmarksOpener = null;
     restoreFocus(opener);
+    resumeChromeHide();
   }
 
   function openAnnotations(): void {
+    pauseChromeHide();
     annotationsOpener = activeElement();
     annotationsVisible = true;
     settingsVisible = false;
@@ -300,9 +322,11 @@
     const opener = annotationsOpener;
     annotationsOpener = null;
     restoreFocus(opener);
+    resumeChromeHide();
   }
 
   function openSearch(): void {
+    pauseChromeHide();
     searchOpener = activeElement();
     searchVisible = true;
     settingsVisible = false;
@@ -324,6 +348,7 @@
     const opener = searchOpener;
     searchOpener = null;
     restoreFocus(opener);
+    resumeChromeHide();
   }
 
   function showFooter(): void {
@@ -334,12 +359,9 @@
   function scheduleChromeHide(): void {
     if (hideTimer !== null) window.clearTimeout(hideTimer);
     hideTimer = window.setTimeout(() => {
+      hideTimer = null;
+      if (hasOpenReaderPanel()) return;
       controlsVisible = false;
-      closeSettings();
-      closeToc();
-      closeBookmarks();
-      closeAnnotations();
-      closeSearch();
       footerVisible = false;
     }, 5_000);
   }


### PR DESCRIPTION
## Problem
Opening a reader panel starts the same five-second chrome timer used for transient reading controls. After the timer fires, bookmarks, contents, search, annotations, or reading appearance closes even when the user is still interacting with it.

## Change
- pause the transient chrome timer while a reader panel is open
- keep panels open until the user closes them
- restart the normal five-second control timeout after the panel closes
- preserve the existing timeout for the controls and footer when no panel is open

## Validation
- `npm test` (27 files, 136 tests)
- `npm run check`
- `npm run lint`
- `npm run format:check`
- live signed Android build installed on Pixel 6 over ADB
- bookmarks panel remained present after six seconds; after closing it, controls hid after six seconds
