### PR TITLE
Close reader panels with Android Back

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: close reader panels with Android Back
 - fix: publish releases without a checkout
 - fix: normalize finalized release notes
 - ci: use software-compatible Android smoke image

--- a/src/lib/components/Library.svelte
+++ b/src/lib/components/Library.svelte
@@ -291,6 +291,7 @@
     xpath: string | null;
     percentage: number | null;
   } | null>(null);
+  let readerBackHandler: (() => boolean) | null = null;
   let conflict = $state<{
     book: BookRecord;
     url: string;
@@ -573,8 +574,10 @@
         await App.addListener('backButton', () => {
           if (destroyed) return;
           if (actionMenuBook) closeMenu();
-          else if (reading) reading = null;
-          else if (settingsVisible) closeSettings();
+          else if (reading) {
+            if (readerBackHandler || document.querySelector('[data-reader-panel]')) return;
+            reading = null;
+          } else if (settingsVisible) closeSettings();
           else void App.exitApp();
         }),
       ),
@@ -1011,6 +1014,13 @@
     void relocated(reading.book, location);
   }
 
+  function registerReaderBackHandler(handler: () => boolean): () => void {
+    readerBackHandler = handler;
+    return () => {
+      if (readerBackHandler === handler) readerBackHandler = null;
+    };
+  }
+
   async function updateApiKey(event: SubmitEvent): Promise<void> {
     event.preventDefault();
     settingsError = '';
@@ -1085,6 +1095,7 @@
     onBack={() => (reading = null)}
     onRelocated={handleRelocated}
     onSyncLatest={() => syncLatestForReader(reading!.book)}
+    registerBackHandler={registerReaderBackHandler}
   />
 {:else}
   <main

--- a/src/lib/components/Reader.svelte
+++ b/src/lib/components/Reader.svelte
@@ -52,6 +52,7 @@
     onBack,
     onRelocated,
     onSyncLatest,
+    registerBackHandler,
   }: {
     bookUrl: string;
     bookId: string;
@@ -62,6 +63,7 @@
     onBack: () => void;
     onRelocated: (location: ReaderLocation) => void;
     onSyncLatest?: () => Promise<{ xpath: string | null; percentage: number | null } | null>;
+    registerBackHandler?: (handler: () => boolean) => () => void;
   } = $props();
 
   let viewport: HTMLDivElement;
@@ -104,6 +106,7 @@
   let bottomSwipeStart: { id: number; x: number; y: number } | null = null;
   let saveTimer: number | null = null;
   let resumeHandle: PluginListenerHandle | null = null;
+  let removeBackHandler: (() => void) | null = null;
   let syncingLatest = $state(false);
   let destroyed = false;
   let appearanceLoaded = false;
@@ -118,7 +121,9 @@
     : null;
 
   onMount(async () => {
+    if (registerBackHandler) removeBackHandler = registerBackHandler(handleBackButton);
     window.addEventListener('keydown', handleKeyboardNavigation);
+    document.addEventListener('backbutton', handleDocumentBackButton);
     const saved = await getPreference('appearance');
     if (destroyed) return;
     if (saved) appearance = parseAppearance(saved);
@@ -191,7 +196,10 @@
 
   onDestroy(() => {
     destroyed = true;
+    removeBackHandler?.();
+    removeBackHandler = null;
     window.removeEventListener('keydown', handleKeyboardNavigation);
+    document.removeEventListener('backbutton', handleDocumentBackButton);
     if (hideTimer !== null) window.clearTimeout(hideTimer);
     if (saveTimer !== null) window.clearTimeout(saveTimer);
     searchController?.abort();
@@ -574,6 +582,24 @@
     }
   }
 
+  function handleBackButton(): boolean {
+    if (settingsVisible) closeSettings();
+    else if (tocVisible) closeToc();
+    else if (bookmarksVisible) closeBookmarks();
+    else if (annotationsVisible) closeAnnotations();
+    else if (searchVisible) closeSearch();
+    else {
+      onBack();
+      return true;
+    }
+    showControls();
+    return true;
+  }
+
+  function handleDocumentBackButton(event: Event): void {
+    if (handleBackButton()) event.preventDefault();
+  }
+
   function handleBottomSwipeStart(event: PointerEvent): void {
     if (event.pointerType === 'mouse' && event.button !== 0) return;
     bottomSwipeStart = { id: event.pointerId, x: event.clientX, y: event.clientY };
@@ -793,6 +819,7 @@
         <div
           bind:this={settingsPanel}
           class="reader-settings card preset-filled-surface-50-950 relative"
+          data-reader-panel
           id="reader-appearance"
           role="dialog"
           aria-modal="true"
@@ -940,6 +967,7 @@
         <div
           bind:this={tocPanel}
           class="reader-settings card preset-filled-surface-50-950 relative"
+          data-reader-panel
           id="reader-contents"
           role="dialog"
           aria-modal="true"
@@ -982,6 +1010,7 @@
         <div
           bind:this={searchPanel}
           class="reader-settings card preset-filled-surface-50-950 relative max-h-[75dvh] overflow-auto"
+          data-reader-panel
           id="reader-search"
           role="dialog"
           aria-modal="true"
@@ -1053,6 +1082,7 @@
         <div
           bind:this={bookmarksPanel}
           class="reader-settings card preset-filled-surface-50-950 relative max-h-[75dvh] overflow-auto"
+          data-reader-panel
           id="reader-bookmarks"
           role="dialog"
           aria-modal="true"
@@ -1182,6 +1212,7 @@
         <div
           bind:this={annotationsPanel}
           class="reader-settings card preset-filled-surface-50-950 relative max-h-[75dvh] overflow-auto"
+          data-reader-panel
           id="reader-annotations"
           role="dialog"
           aria-modal="true"


### PR DESCRIPTION
## Problem
On Android, pressing the hardware Back button while a reader panel is open exits the reader instead of closing the panel. This loses the user's reading context and differs from Escape and the panel close controls.

## Change
- keep the library Back handler from consuming Back while a reader is active
- let the reader handle the document back event and close the active panel first
- return to the library only when Back is pressed with no panel open
- mark reader panels so the library can safely recognize an active panel during the native event

## Validation
- `npm test` (27 files, 136 tests)
- `npm run check`
- `npm run lint`
- `npm run format:check`
- signed Android build installed on Pixel 6 over ADB
- first hardware Back closed the bookmarks panel and kept the reader open; second Back returned to the library
