### PR TITLE
Keep settings controls visible while scrolling

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: keep settings controls visible while scrolling
 - fix: publish releases without a checkout
 - fix: normalize finalized release notes
 - ci: use software-compatible Android smoke image

--- a/src/lib/components/Library.svelte
+++ b/src/lib/components/Library.svelte
@@ -1762,7 +1762,7 @@
   >
     <div
       bind:this={settingsDialog}
-      class="card preset-filled-surface-50-950 relative w-full max-w-md max-h-[88dvh] overflow-auto p-6"
+      class="card preset-filled-surface-50-950 relative max-h-[88dvh] w-full max-w-md overflow-auto p-6"
       role="dialog"
       aria-modal="true"
       aria-labelledby="library-settings-title"
@@ -1770,21 +1770,24 @@
       onkeydown={(event) => trapModalKeydown(event, settingsDialog!, closeSettings)}
       transition:fly={{ y: 16, duration: 150 }}
     >
-      <button
-        class="btn btn-sm preset-tonal-surface absolute right-4 top-4 h-9 w-9 p-0"
-        type="button"
-        onclick={closeSettings}
-        aria-label="Close settings"
+      <div
+        class="sticky top-0 z-10 -mx-6 -mt-6 mb-6 flex items-center justify-between gap-3 bg-inherit px-6 pb-3 pt-6"
       >
-        <svg aria-hidden="true" viewBox="0 0 24 24" class="h-5 w-5">
-          <path
-            fill="currentColor"
-            d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-          />
-        </svg>
-      </button>
-
-      <h2 id="library-settings-title" class="font-serif text-3xl">Settings</h2>
+        <h2 id="library-settings-title" class="font-serif text-3xl">Settings</h2>
+        <button
+          class="btn btn-sm preset-tonal-surface h-9 w-9 shrink-0 p-0"
+          type="button"
+          onclick={closeSettings}
+          aria-label="Close settings"
+        >
+          <svg aria-hidden="true" viewBox="0 0 24 24" class="h-5 w-5">
+            <path
+              fill="currentColor"
+              d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+            />
+          </svg>
+        </button>
+      </div>
 
       <div class="mt-6" aria-labelledby="library-settings-appearance-title">
         <h3 id="library-settings-appearance-title" class="text-lg font-medium">


### PR DESCRIPTION
## Problem
The library settings dialog is scrollable, but its title and close button scroll with the content. On a phone, a user who reaches the connection or storage sections loses the visible way to dismiss settings.

## Change
- keep the Settings heading and close button in a sticky dialog header
- preserve the existing scrollable content and focus behavior
- keep the header background above the content while scrolling

## Validation
- `npm test` (27 files, 136 tests)
- `npm run check`
- `npm run lint`
- `npm run format:check`
- signed Android build installed on Pixel 6 over ADB
- after scrolling to Storage and maintenance, the close button remained visible and closed the dialog
