### PR TITLE
Hide advanced library filters behind a panel

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: hide advanced library filters behind panel
 - fix: publish releases without a checkout
 - fix: normalize finalized release notes
 - ci: use software-compatible Android smoke image

--- a/src/lib/components/Library.svelte
+++ b/src/lib/components/Library.svelte
@@ -226,7 +226,11 @@
   let sortOrder = $state<LibrarySortOrder>('title');
   let authorFilter = $state('');
   let seriesFilter = $state('');
+  let filtersVisible = $state(false);
   let viewMode = $state<LibraryViewMode>('grid');
+  let advancedFiltersActive = $derived(
+    sortOrder !== 'title' || Boolean(authorFilter) || Boolean(seriesFilter),
+  );
   let authors = $derived(
     [
       ...new Set(
@@ -1226,9 +1230,13 @@
           </button>
         {/if}
       </label>
-      <div class="grid grid-cols-2">
+      <div
+        class="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]"
+        role="group"
+        aria-label="Library filters"
+      >
         <button
-          class="h-8 !px-2 !py-0 btn btn-sm !text-sm rounded-none {downloadedOnly
+          class="h-10 !px-2 !py-0 btn btn-sm !text-sm rounded-none {downloadedOnly
             ? 'preset-filled-primary-700-300'
             : 'preset-filled-tertiary-100-900'}"
           type="button"
@@ -1242,7 +1250,7 @@
           <span>Downloaded Only</span>
         </button>
         <button
-          class="h-8 !px-2 !py-0 btn btn-sm !text-sm rounded-none {hideCompleted
+          class="h-10 !px-2 !py-0 btn btn-sm !text-sm rounded-none {hideCompleted
             ? 'preset-filled-secondary-100-900'
             : 'preset-filled-primary-700-300'}"
           type="button"
@@ -1258,48 +1266,81 @@
           </svg>
           <span>Hide completed</span>
         </button>
+        <button
+          class="btn btn-sm h-10 w-11 !p-0 rounded-none {filtersVisible || advancedFiltersActive
+            ? 'preset-filled-primary-700-300'
+            : 'preset-filled-tertiary-100-900'}"
+          type="button"
+          aria-expanded={filtersVisible}
+          aria-controls="library-filter-panel"
+          aria-label={filtersVisible ? 'Hide library filters' : 'Show library filters'}
+          title="More filters and sorting"
+          onclick={() => (filtersVisible = !filtersVisible)}
+        >
+          <svg aria-hidden="true" viewBox="0 0 24 24" class="h-5 w-5">
+            <path fill="currentColor" d="M3 5h18v2H3V5zm3 6h12v2H6v-2zm3 6h6v2H9v-2z" />
+          </svg>
+        </button>
       </div>
-      <label class="mt-2 flex items-center gap-2 text-sm text-surface-700-300">
-        <span>Sort</span>
-        <select
-          class="select preset-tonal-surface h-10 min-w-32"
-          aria-label="Sort books"
-          value={sortOrder}
-          onchange={handleSortChange}
+      {#if filtersVisible}
+        <div
+          id="library-filter-panel"
+          class="preset-tonal-surface mt-3 rounded-xl border border-surface-300/40 p-4"
+          role="region"
+          aria-labelledby="library-filter-panel-title"
+          transition:fly={{ y: -8, duration: 160 }}
         >
-          <option value="title">Title</option>
-          <option value="author">Author</option>
-          <option value="recent">Recently read</option>
-        </select>
-      </label>
-      <label class="mt-2 flex items-center gap-2 text-sm text-surface-700-300">
-        <span>Author</span>
-        <select
-          class="select preset-tonal-surface h-10 min-w-36"
-          aria-label="Filter by author"
-          value={authorFilter}
-          onchange={handleAuthorChange}
-        >
-          <option value="">All authors</option>
-          {#each authors as author (author)}
-            <option value={author}>{author}</option>
-          {/each}
-        </select>
-      </label>
-      <label class="mt-2 flex items-center gap-2 text-sm text-surface-700-300">
-        <span>Series</span>
-        <select
-          class="select preset-tonal-surface h-10 min-w-36"
-          aria-label="Filter by series"
-          value={seriesFilter}
-          onchange={handleSeriesChange}
-        >
-          <option value="">All series</option>
-          {#each seriesNames as series (series)}
-            <option value={series}>{series}</option>
-          {/each}
-        </select>
-      </label>
+          <div class="flex items-center justify-between gap-3">
+            <h2 id="library-filter-panel-title" class="text-sm font-medium">More filters</h2>
+            {#if advancedFiltersActive}
+              <span class="text-xs text-surface-700-300">Filters active</span>
+            {/if}
+          </div>
+          <div class="mt-3 grid gap-3 sm:grid-cols-3">
+            <label class="label">
+              <span class="label-text">Sort order</span>
+              <select
+                class="select preset-tonal-surface"
+                aria-label="Sort books"
+                value={sortOrder}
+                onchange={handleSortChange}
+              >
+                <option value="title">Title</option>
+                <option value="author">Author</option>
+                <option value="recent">Recently read</option>
+              </select>
+            </label>
+            <label class="label">
+              <span class="label-text">Author</span>
+              <select
+                class="select preset-tonal-surface"
+                aria-label="Filter by author"
+                value={authorFilter}
+                onchange={handleAuthorChange}
+              >
+                <option value="">All authors</option>
+                {#each authors as author (author)}
+                  <option value={author}>{author}</option>
+                {/each}
+              </select>
+            </label>
+            <label class="label">
+              <span class="label-text">Series</span>
+              <select
+                class="select preset-tonal-surface"
+                aria-label="Filter by series"
+                value={seriesFilter}
+                onchange={handleSeriesChange}
+              >
+                <option value="">All series</option>
+                {#each seriesNames as series (series)}
+                  <option value={series}>{series}</option>
+                {/each}
+              </select>
+            </label>
+          </div>
+        </div>
+      {/if}
       <div class="mt-2 flex items-center gap-1" role="group" aria-label="Library view">
         <button
           class="btn btn-sm h-10 {viewMode === 'grid'


### PR DESCRIPTION
## Problem
The library shows sorting and author/series selectors inline with the primary filters, which makes the mobile toolbar crowded and pushes the book grid down.

## Change
- keep Downloaded Only and Hide completed visible as primary toggles
- add an accessible icon-only filter disclosure button beside them
- move sort order, author, and series selectors into a distinct panel
- animate the panel with a Svelte fly transition on open and close
- preserve active-filter state and existing saved preferences

## Validation
- npm test -- --run
- npm run check
- npm run lint
- npm run format:check
- signed Android build installed and exercised on a Pixel 6 over ADB
- verified panel disclosure semantics and closing transition with UIAutomator
