### PR TITLE
Reduce reader bottom spacing

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: reduce reader bottom spacing
 - fix: publish releases without a checkout
 - fix: normalize finalized release notes
 - ci: use software-compatible Android smoke image

--- a/src/lib/components/Reader.svelte
+++ b/src/lib/components/Reader.svelte
@@ -878,6 +878,19 @@
             />
           </label>
           <label class="label mt-4">
+            <span class="label-text">Bottom margin: {appearance.bottomMargin} pixels</span>
+            <input
+              class="range"
+              type="range"
+              min="0"
+              max="64"
+              step="2"
+              value={appearance.bottomMargin}
+              oninput={(event) =>
+                updateAppearance({ bottomMargin: Number(event.currentTarget.value) })}
+            />
+          </label>
+          <label class="label mt-4">
             <span class="label-text"
               >Paragraph spacing: {appearance.paragraphSpacing.toFixed(1)}</span
             >

--- a/src/lib/reader/appearance.test.ts
+++ b/src/lib/reader/appearance.test.ts
@@ -8,10 +8,16 @@ describe('appearance serialization', () => {
   });
 
   it('bounds unsafe numeric values', () => {
-    expect(parseAppearance('{"fontSize":200,"lineHeight":0}')).toMatchObject({
+    expect(parseAppearance('{"fontSize":200,"lineHeight":0,"bottomMargin":200}')).toMatchObject({
       fontSize: 34,
       lineHeight: 1.2,
+      bottomMargin: 64,
     });
+  });
+
+  it('defaults the bottom margin for older saved appearances', () => {
+    expect(parseAppearance('{}').bottomMargin).toBe(defaultAppearance.bottomMargin);
+    expect(parseAppearance('{"bottomMargin":-4}').bottomMargin).toBe(0);
   });
 
   it('defaults the progress bar on', () => {

--- a/src/lib/reader/appearance.ts
+++ b/src/lib/reader/appearance.ts
@@ -7,6 +7,7 @@ export interface Appearance {
   lineHeight: number;
   paragraphSpacing: number;
   margin: number;
+  bottomMargin: number;
   alignment: 'start' | 'justify';
   publisherStyles: boolean;
   hyphenation: boolean;
@@ -21,6 +22,7 @@ export const defaultAppearance: Appearance = {
   lineHeight: 1.55,
   paragraphSpacing: 0.6,
   margin: 24,
+  bottomMargin: 0,
   alignment: 'start',
   publisherStyles: true,
   hyphenation: false,
@@ -43,6 +45,10 @@ export function parseAppearance(value: string): Appearance {
     lineHeight: Math.min(
       2,
       Math.max(1.2, Number(parsed.lineHeight ?? defaultAppearance.lineHeight)),
+    ),
+    bottomMargin: Math.min(
+      64,
+      Math.max(0, Number(parsed.bottomMargin ?? defaultAppearance.bottomMargin)),
     ),
     progressBar: parsed.progressBar !== false,
   };

--- a/src/lib/reader/session.ts
+++ b/src/lib/reader/session.ts
@@ -546,7 +546,7 @@ export class ReaderSession {
         'font-family': `${family} !important`,
         'font-size': `${value.fontSize}px !important`,
         'line-height': `${value.lineHeight} !important`,
-        padding: `0.5rem max(${value.margin}px, env(safe-area-inset-right)) calc(max(${value.margin}px, env(safe-area-inset-bottom)) + 2.5rem) max(${value.margin}px, env(safe-area-inset-left)) !important`,
+        padding: `0.5rem max(${value.margin}px, env(safe-area-inset-right)) max(${value.bottomMargin}px, env(safe-area-inset-bottom)) max(${value.margin}px, env(safe-area-inset-left)) !important`,
         'box-sizing': 'border-box',
       },
       p: {


### PR DESCRIPTION
## Problem
The reader reserves a large fixed block below EPUB content, leaving an oversized blank area above the gesture bar on mobile devices.

## Change
- remove the fixed 2.5rem EPUB bottom reserve
- honor the device safe-area inset directly for bottom padding
- default the configurable bottom margin to zero while allowing up to 64 pixels in Reading appearance
- preserve and bounds-check the new preference for older saved appearances

## Validation
- npm test -- --run (27 files, 137 tests)
- npm run check
- npm run lint
- npm run format:check
- signed Android release build installed on a Pixel 6 over ADB
- reader screenshot verified substantially more text fits before the gesture bar
