### PR TITLE
Align library view controls and compact filter actions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: align library view controls and filter actions
 - fix: hide advanced library filters behind panel
 - fix: publish releases without a checkout
 - fix: normalize finalized release notes

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: hide advanced library filters behind panel
 - fix: publish releases without a checkout
 - fix: normalize finalized release notes
 - ci: use software-compatible Android smoke image

--- a/src/lib/components/Library.svelte
+++ b/src/lib/components/Library.svelte
@@ -231,6 +231,9 @@
   let advancedFiltersActive = $derived(
     sortOrder !== 'title' || Boolean(authorFilter) || Boolean(seriesFilter),
   );
+  let libraryFiltersActive = $derived(
+    Boolean(query.trim()) || downloadedOnly || hideCompleted || advancedFiltersActive,
+  );
   let authors = $derived(
     [
       ...new Set(
@@ -391,11 +394,9 @@
     authorFilter = '';
     seriesFilter = '';
     sortOrder = 'title';
-    viewMode = 'grid';
     void setPreference('librarySort', sortOrder);
     void setPreference('libraryAuthor', authorFilter);
     void setPreference('librarySeries', seriesFilter);
-    void setPreference('libraryView', viewMode);
   }
 
   function activeElement(): HTMLElement | null {
@@ -1231,7 +1232,7 @@
         {/if}
       </label>
       <div
-        class="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]"
+        class="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto_auto]"
         role="group"
         aria-label="Library filters"
       >
@@ -1281,6 +1282,22 @@
             <path fill="currentColor" d="M3 5h18v2H3V5zm3 6h12v2H6v-2zm3 6h6v2H9v-2z" />
           </svg>
         </button>
+        {#if libraryFiltersActive}
+          <button
+            class="btn btn-sm h-10 w-11 !p-0 rounded-none preset-tonal-surface"
+            type="button"
+            onclick={clearFilters}
+            aria-label="Clear library filters"
+            title="Clear filters"
+          >
+            <svg aria-hidden="true" viewBox="0 0 24 24" class="h-5 w-5">
+              <path
+                fill="currentColor"
+                d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+              />
+            </svg>
+          </button>
+        {/if}
       </div>
       {#if filtersVisible}
         <div
@@ -1341,38 +1358,35 @@
           </div>
         </div>
       {/if}
-      <div class="mt-2 flex items-center gap-1" role="group" aria-label="Library view">
-        <button
-          class="btn btn-sm h-10 {viewMode === 'grid'
-            ? 'preset-filled-primary-700-300'
-            : 'preset-tonal-surface'}"
-          type="button"
-          aria-pressed={viewMode === 'grid'}
-          onclick={() => handleViewModeChange('grid')}
-        >
-          Grid
-        </button>
-        <button
-          class="btn btn-sm h-10 {viewMode === 'list'
-            ? 'preset-filled-primary-700-300'
-            : 'preset-tonal-surface'}"
-          type="button"
-          aria-pressed={viewMode === 'list'}
-          onclick={() => handleViewModeChange('list')}
-        >
-          List
-        </button>
-      </div>
     </div>
 
     {#if !loading && books.length > 0}
-      <div class="mt-4 flex items-center justify-between gap-3 text-sm text-surface-700-300">
+      <div
+        class="mt-4 flex flex-wrap items-center justify-between gap-3 text-sm text-surface-700-300"
+      >
         <p>{visibleBooks.length} of {books.length} books</p>
-        {#if query || downloadedOnly || hideCompleted || sortOrder !== 'title' || authorFilter || seriesFilter || viewMode !== 'grid'}
-          <button class="btn btn-sm preset-tonal-surface h-10" type="button" onclick={clearFilters}>
-            Clear filters
+        <div class="flex items-center gap-1" role="group" aria-label="Library view">
+          <button
+            class="btn btn-sm h-10 {viewMode === 'grid'
+              ? 'preset-filled-primary-700-300'
+              : 'preset-tonal-surface'}"
+            type="button"
+            aria-pressed={viewMode === 'grid'}
+            onclick={() => handleViewModeChange('grid')}
+          >
+            Grid
           </button>
-        {/if}
+          <button
+            class="btn btn-sm h-10 {viewMode === 'list'
+              ? 'preset-filled-primary-700-300'
+              : 'preset-tonal-surface'}"
+            type="button"
+            aria-pressed={viewMode === 'list'}
+            onclick={() => handleViewModeChange('list')}
+          >
+            List
+          </button>
+        </div>
       </div>
     {/if}
 

--- a/src/lib/components/Library.svelte
+++ b/src/lib/components/Library.svelte
@@ -226,7 +226,11 @@
   let sortOrder = $state<LibrarySortOrder>('title');
   let authorFilter = $state('');
   let seriesFilter = $state('');
+  let filtersVisible = $state(false);
   let viewMode = $state<LibraryViewMode>('grid');
+  let advancedFiltersActive = $derived(
+    sortOrder !== 'title' || Boolean(authorFilter) || Boolean(seriesFilter),
+  );
   let authors = $derived(
     [
       ...new Set(
@@ -1226,9 +1230,13 @@
           </button>
         {/if}
       </label>
-      <div class="grid grid-cols-2">
+      <div
+        class="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]"
+        role="group"
+        aria-label="Library filters"
+      >
         <button
-          class="h-8 !px-2 !py-0 btn btn-sm !text-sm rounded-none {downloadedOnly
+          class="h-10 !px-2 !py-0 btn btn-sm !text-sm rounded-none {downloadedOnly
             ? 'preset-filled-primary-700-300'
             : 'preset-filled-tertiary-100-900'}"
           type="button"
@@ -1242,7 +1250,7 @@
           <span>Downloaded Only</span>
         </button>
         <button
-          class="h-8 !px-2 !py-0 btn btn-sm !text-sm rounded-none {hideCompleted
+          class="h-10 !px-2 !py-0 btn btn-sm !text-sm rounded-none {hideCompleted
             ? 'preset-filled-secondary-100-900'
             : 'preset-filled-primary-700-300'}"
           type="button"
@@ -1258,48 +1266,81 @@
           </svg>
           <span>Hide completed</span>
         </button>
+        <button
+          class="btn btn-sm h-10 w-11 !p-0 rounded-none {filtersVisible || advancedFiltersActive
+            ? 'preset-filled-primary-700-300'
+            : 'preset-filled-tertiary-100-900'}"
+          type="button"
+          aria-expanded={filtersVisible}
+          aria-controls="library-filter-panel"
+          aria-label={filtersVisible ? 'Hide library filters' : 'Show library filters'}
+          title="More filters and sorting"
+          onclick={() => (filtersVisible = !filtersVisible)}
+        >
+          <svg aria-hidden="true" viewBox="0 0 24 24" class="h-5 w-5">
+            <path fill="currentColor" d="M3 5h18v2H3V5zm3 6h12v2H6v-2zm3 6h6v2H9v-2z" />
+          </svg>
+        </button>
       </div>
-      <label class="mt-2 flex items-center gap-2 text-sm text-surface-700-300">
-        <span>Sort</span>
-        <select
-          class="select preset-tonal-surface h-10 min-w-32"
-          aria-label="Sort books"
-          value={sortOrder}
-          onchange={handleSortChange}
+      {#if filtersVisible}
+        <div
+          id="library-filter-panel"
+          class="preset-tonal-surface mt-3 rounded-xl border border-surface-300/40 p-4"
+          role="region"
+          aria-labelledby="library-filter-panel-title"
+          transition:fly={{ y: -8, duration: 160 }}
         >
-          <option value="title">Title</option>
-          <option value="author">Author</option>
-          <option value="recent">Recently read</option>
-        </select>
-      </label>
-      <label class="mt-2 flex items-center gap-2 text-sm text-surface-700-300">
-        <span>Author</span>
-        <select
-          class="select preset-tonal-surface h-10 min-w-36"
-          aria-label="Filter by author"
-          value={authorFilter}
-          onchange={handleAuthorChange}
-        >
-          <option value="">All authors</option>
-          {#each authors as author (author)}
-            <option value={author}>{author}</option>
-          {/each}
-        </select>
-      </label>
-      <label class="mt-2 flex items-center gap-2 text-sm text-surface-700-300">
-        <span>Series</span>
-        <select
-          class="select preset-tonal-surface h-10 min-w-36"
-          aria-label="Filter by series"
-          value={seriesFilter}
-          onchange={handleSeriesChange}
-        >
-          <option value="">All series</option>
-          {#each seriesNames as series (series)}
-            <option value={series}>{series}</option>
-          {/each}
-        </select>
-      </label>
+          <div class="flex items-center justify-between gap-3">
+            <h2 id="library-filter-panel-title" class="text-sm font-medium">More filters</h2>
+            {#if advancedFiltersActive}
+              <span class="text-xs text-surface-700-300">Filters active</span>
+            {/if}
+          </div>
+          <div class="mt-3 grid gap-3 sm:grid-cols-3">
+            <label class="label">
+              <span class="label-text">Sort order</span>
+              <select
+                class="select preset-tonal-surface"
+                aria-label="Sort books"
+                value={sortOrder}
+                onchange={handleSortChange}
+              >
+                <option value="title">Title</option>
+                <option value="author">Author</option>
+                <option value="recent">Recently read</option>
+              </select>
+            </label>
+            <label class="label">
+              <span class="label-text">Author</span>
+              <select
+                class="select preset-tonal-surface"
+                aria-label="Filter by author"
+                value={authorFilter}
+                onchange={handleAuthorChange}
+              >
+                <option value="">All authors</option>
+                {#each authors as author (author)}
+                  <option value={author}>{author}</option>
+                {/each}
+              </select>
+            </label>
+            <label class="label">
+              <span class="label-text">Series</span>
+              <select
+                class="select preset-tonal-surface"
+                aria-label="Filter by series"
+                value={seriesFilter}
+                onchange={handleSeriesChange}
+              >
+                <option value="">All series</option>
+                {#each seriesNames as series (series)}
+                  <option value={series}>{series}</option>
+                {/each}
+              </select>
+            </label>
+          </div>
+        </div>
+      {/if}
       <div class="mt-2 flex items-center gap-1" role="group" aria-label="Library view">
         <button
           class="btn btn-sm h-10 {viewMode === 'grid'


### PR DESCRIPTION
## Problem
The library view toggles sit in the primary filter toolbar while the result count and a full-width Clear filters button sit below it, making the controls feel disconnected and consuming extra space.

## Change
- move Grid and List controls beside the visible-book count
- place the icon-only clear action beside the advanced-filter disclosure
- keep filter clearing limited to search, filter, and sort state so it does not reset the selected view
- retain accessible labels and the existing filter-panel transition

## Validation
- `npm test -- --run` (27 files, 136 tests)
- `npm run check`
- `npm run lint`
- `npm run format:check`
- signed Android release build installed on the connected Pixel 6 over ADB
- verified toolbar alignment, filter-panel disclosure, compact clear action, and view preservation with UIAutomator and screenshots

This is intentionally stacked on the filter-panel change in PR #102.
