### PR TITLE
Fix narrow-screen library filter controls

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: compact library filter toggles on narrow screens
 - fix: reduce reader bottom spacing
 - fix: place library book actions with each card
 - fix: align library view controls and filter actions

--- a/src/lib/components/Library.svelte
+++ b/src/lib/components/Library.svelte
@@ -1248,25 +1248,28 @@
         aria-label="Library filters"
       >
         <button
-          class="h-10 !px-2 !py-0 btn btn-sm !text-sm rounded-none {downloadedOnly
+          class="h-10 !px-2 !py-0 btn btn-sm !text-xs sm:!text-sm rounded-none {downloadedOnly
             ? 'preset-filled-primary-700-300'
             : 'preset-filled-tertiary-100-900'}"
           type="button"
           aria-pressed={downloadedOnly}
+          aria-label="Show only downloaded books"
           onclick={() => (downloadedOnly = !downloadedOnly)}
           title="Show only downloaded books"
         >
           <svg aria-hidden="true" viewBox="0 0 24 24" class="h-4 w-4">
             <path fill="currentColor" d="M5 20h14v-2H5v2zM19 9h-4V3H9v6H5l7 7 7-7z" />
           </svg>
-          <span>Downloaded Only</span>
+          <span class="sm:hidden">Downloaded</span>
+          <span class="hidden sm:inline">Downloaded Only</span>
         </button>
         <button
-          class="h-10 !px-2 !py-0 btn btn-sm !text-sm rounded-none {hideCompleted
+          class="h-10 !px-2 !py-0 btn btn-sm !text-xs sm:!text-sm rounded-none {hideCompleted
             ? 'preset-filled-secondary-100-900'
             : 'preset-filled-primary-700-300'}"
           type="button"
           aria-pressed={hideCompleted}
+          aria-label="Hide books you have finished"
           onclick={() => (hideCompleted = !hideCompleted)}
           title="Hide books you have finished"
         >
@@ -1276,7 +1279,8 @@
               d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17a5 5 0 1 1 0-10 5 5 0 0 1 0 10zm0-8a3 3 0 1 0 0 6 3 3 0 0 0 0-6z"
             />
           </svg>
-          <span>Hide completed</span>
+          <span class="sm:hidden">Hide done</span>
+          <span class="hidden sm:inline">Hide completed</span>
         </button>
         <button
           class="btn btn-sm h-10 w-11 !p-0 rounded-none {filtersVisible || advancedFiltersActive


### PR DESCRIPTION
## Problem
The library's `Downloaded Only` and `Hide completed` toggles were cramped on narrow Android screens, leaving little space between their icons and labels.

## Change
- Use shorter labels (`Downloaded` and `Hide done`) below the `sm` breakpoint.
- Keep the full labels on larger screens.
- Add explicit accessible names while retaining the existing tooltips and toggle behavior.

## Validation
- `npm run check`
- `npm run lint`
- `npm run format:check`
- `npm run test -- --run` (27 files, 139 tests)
- Built and installed release APK on TLC (`T702Z`, Android 15, 1080x2460 at 480 dpi / ~360 dp).
- Verified the narrow toolbar labels, filter panel transition/layout, toggle result counts, and restored filter state on-device.
